### PR TITLE
feat: add custom parameters template substitution.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,6 +214,53 @@ To configure parameter processors add the following snippet to your Ansible vari
           - 'customer_package.lti_processors:team_and_cohort'
           - 'example_package.lti_processors:extra_lti_params'
 
+Dynamic LTI Custom Parameters
+=============================
+
+This XBlock gives us the capability to attach static and dynamic custom parameters in the custom parameters field,
+in the case we need to declare a dynamic custom parameter we must set the value of the parameter as a templated parameter
+wrapped with the tags '${' and '}' just like the following example:
+
+.. code:: python
+
+    ["static_param=static_value", "dynamic_custom_param=${templated_param_value}"]
+
+Defining a dynamic LTI Custom Parameter Processor
+-------------------------------------------------
+
+The custom parameter processor is a function that expects an XBlock instance, and returns a ``string`` which should be the resolved value.
+Exceptions must be handled by the processor itself.
+
+.. code:: python
+
+    def get_course_name(xblock):
+        try:
+            course = CourseOverview.objects.get(id=xblock.course.id)
+        except CourseOverview.DoesNotExist:
+            log.error('Course does not exist.')
+            return ''
+
+        return course.display_name
+
+Note. The processor function must return a ``string`` object.
+
+Configuring the LTI Dynamic Custom Parameters Settings
+------------------------------------------------------
+
+The setting LTI_CUSTOM_PARAM_TEMPLATES must be set in order to map the template value for the dynamic custom parameter
+as the following example:
+
+.. code:: python
+
+    LTI_CUSTOM_PARAM_TEMPLATES = {
+        'templated_param_value': 'customer_package.module:func',
+    }
+
+* 'templated_param_value': custom parameter template name.
+* 'customer_package.module:func': custom parameter processor path and function name.
+
+
+
 LTI Advantage Features
 ======================
 
@@ -319,6 +366,11 @@ Changelog
 =========
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
+
+3.2.0 - 2022-01-18
+-------------------
+
+* Dynamic custom parameters support with the help of template parameter processors.
 
 3.1.2 - 2021-11-12
 -------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .lti_xblock import LtiConsumerXBlock
 from .apps import LTIConsumerApp
 
-__version__ = '3.1.2'
+__version__ = '3.2.0'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -81,7 +81,7 @@ from .lti_1p3.exceptions import (
 )
 from .lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from .outcomes import OutcomeService
-from .utils import _
+from .utils import _, resolve_custom_parameter_template
 
 
 log = logging.getLogger(__name__)
@@ -100,6 +100,7 @@ ROLE_MAP = {
     'staff': 'Administrator',
     'instructor': 'Instructor',
 }
+CUSTOM_PARAMETER_TEMPLATE_TAGS = ('${', '}')
 
 
 def parse_handler_suffix(suffix):
@@ -818,6 +819,10 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 # LTI specs: 'custom_' should be prepended before each custom parameter, as pointed in link above.
                 if param_name not in LTI_PARAMETERS:
                     param_name = 'custom_' + param_name
+
+                if (param_value.startswith(CUSTOM_PARAMETER_TEMPLATE_TAGS[0]) and
+                        param_value.endswith(CUSTOM_PARAMETER_TEMPLATE_TAGS[1])):
+                    param_value = resolve_custom_parameter_template(self, param_value)
 
                 custom_parameters[param_name] = param_value
 

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -1,7 +1,12 @@
 """
 Utility functions for LTI Consumer block
 """
+import logging
+from importlib import import_module
+
 from django.conf import settings
+
+log = logging.getLogger(__name__)
 
 
 def _(text):
@@ -113,3 +118,37 @@ def get_lti_nrps_context_membership_url(lti_config_id):
         lms_base=get_lms_base(),
         lti_config_id=str(lti_config_id),
     )
+
+
+def resolve_custom_parameter_template(xblock, template):
+    """
+    Return the value processed according to the template processor.
+    The template processor must return a string object.
+
+    :param xblock: LTI consumer xblock.
+    :param template: processor key.
+    """
+    try:
+        module_name, func_name = settings.LTI_CUSTOM_PARAM_TEMPLATES.get(
+            template[2:len(template) - 1],
+            ':',
+        ).split(':', 1)
+        template_value = getattr(
+            import_module(module_name),
+            func_name,
+        )(xblock)
+
+        if not isinstance(template_value, str):
+            log.error('The \'%s\' processor must return a string object.', func_name)
+            return template
+    except ValueError:
+        log.error(
+            'Error while processing \'%s\' value. Reason: The template processor definition must be wrong.',
+            template,
+        )
+        return template
+    except (AttributeError, ModuleNotFoundError) as ex:
+        log.error('Error while processing \'%s\' value. Reason: %s', template, str(ex))
+        return template
+
+    return template_value


### PR DESCRIPTION
### Description:

This PR adds the capability to add custom parameter template values in order to be resolved by a processor.

We must have the following configuration in order to make this happen

- Add the following settings variable to map our template values with their corresponding processors. Also, these processors must return a string object.
`LTI_CUSTOM_PARAM_TEMPLATES = { 'templated_param_value': 'customer_package.module:func' }`

- In Studio we will have the custom parameters field value such as:
 `["static_param=static_value", "dynamic_custom_param=&templated_param_value"]`

   **Note.** It must have '&' as a prefix to indicate it is a templated_value to substitute.

Additional:

This feature will be used by [this implementetion](https://github.com/Pearson-Advance/pearson-core/pull/27). Also, we can find a test guide in the mentioned PR.
