### PR TITLE
PADV-332: Send custom parameters on LTI 1.3 launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,3 @@ jobs:
       env:
         TOXENV: ${{ matrix.toxenv }}
       run: tox
-
-    - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='py38-django32'
-      uses: codecov/codecov-action@v1
-      with:
-        flags: unittests
-        fail_ci_if_error: true
-

--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -70,6 +70,7 @@ class Lti1p3LaunchData:
     * proctoring_launch_data (conditionally required): An instance of the Lti1p3ProctoringLaunchData that contains
         data necessary and related to an LTI 1.3 proctoring launch. It is required if the message_type attribute is
         "LtiStartProctoring" or "LtiEndAssessment".
+    * custom_parameters (optional): The custom parameters claim values. It is a dictionary of custom parameters.
     """
     user_id = field()
     user_role = field()
@@ -90,3 +91,4 @@ class Lti1p3LaunchData:
         default=None,
         validator=validators.optional((validators.instance_of(Lti1p3ProctoringLaunchData))),
     )
+    custom_parameters = field(default={})

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -227,6 +227,10 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         # Set LTI Launch URL.
         context.update({'launch_url': preflight_response.get("redirect_uri")})
 
+        # Set LTI custom properties claim.
+        if launch_data.custom_parameters:
+            lti_consumer.set_custom_parameters(launch_data.custom_parameters)
+
         # Modify LTI Launch URL depending on launch type.
         # Deep Linking Launch - Configuration flow launched by
         # course creators to set up content.

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -523,6 +523,46 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
 
+    @patch('lti_consumer.lti_1p3.consumer.LtiConsumer1p3.set_custom_parameters')
+    def test_launch_existing_custom_parameters(self, mock_set_custom_parameters):
+        """
+        Check custom parameters are set if they exist on XBlock configuration.
+        """
+        self.launch_data.custom_parameters = ['test=test']
+        params = {
+            "client_id": self.config.lti_1p3_client_id,
+            "redirect_uri": "http://tool.example/launch",
+            "state": "state_test_123",
+            "nonce": "nonce",
+            "login_hint": self.launch_data.user_id,
+            "lti_message_hint": self.launch_data_key,
+        }
+
+        response = self.client.get(self.url, params)
+
+        self.assertEqual(response.status_code, 200)
+        mock_set_custom_parameters.assert_called_once_with(self.launch_data.custom_parameters)
+
+    @patch('lti_consumer.lti_1p3.consumer.LtiConsumer1p3.set_custom_parameters')
+    def test_launch_non_existing_custom_parameters(self, mock_set_custom_parameters):
+        """
+        Check custom parameters are not set if they don't exist on XBlock configuration.
+        """
+        self.launch_data.custom_parameters = {}
+        params = {
+            "client_id": self.config.lti_1p3_client_id,
+            "redirect_uri": "http://tool.example/launch",
+            "state": "state_test_123",
+            "nonce": "nonce",
+            "login_hint": self.launch_data.user_id,
+            "lti_message_hint": self.launch_data_key,
+        }
+
+        response = self.client.get(self.url, params)
+
+        self.assertEqual(response.status_code, 200)
+        mock_set_custom_parameters.assert_not_called()
+
 
 class TestLti1p3AccessTokenEndpoint(TestCase):
     """

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -15,6 +15,7 @@ from django.test import override_settings
 from django.test.testcases import TestCase
 from django.utils import timezone
 from jwkest.jwk import RSAKey, KEYS
+from xblock.validation import Validation
 
 from lti_consumer.exceptions import LtiError
 
@@ -37,6 +38,14 @@ HTML_ERROR_MESSAGE = '<h3 class="error_message">'
 HTML_LAUNCH_MODAL_BUTTON = 'btn-lti-modal'
 HTML_LAUNCH_NEW_WINDOW_BUTTON = 'btn-lti-new-window'
 HTML_IFRAME = '<iframe'
+VALID_CUSTOM_PARAMETERS = (
+    ['x=y'], ['  x  =  y  '], ['x=${y}'], ['  x  =  ${y} '], ['x=${  y  }'],
+    ['x=y', 'x=${y}', '  x  =  y  ', '  x  =  ${y} ', 'x=${  y  }'],
+)
+INVALID_CUSTOM_PARAMETERS = (
+    ['x'], ['x='], ['x=y y'], ['x={y}'], ['x={y'], ['x=y}'], ['x=*'], ['=y'], ['x x=y'], ['*=y'],
+    ['x', 'x=', 'x=y y', 'x={y}', 'x={y', 'x=y}', 'x=*', '=y', 'x x=y', '*=y'],
+)
 
 
 class TestLtiConsumerXBlock(TestCase):
@@ -87,6 +96,7 @@ class TestIndexibility(TestCase):
         )
 
 
+@ddt.ddt
 class TestProperties(TestLtiConsumerXBlock):
     """
     Unit tests for LtiConsumerXBlock properties
@@ -138,13 +148,45 @@ class TestProperties(TestLtiConsumerXBlock):
         """
         self.assertEqual(self.xblock.context_id, str(self.xblock.scope_ids.usage_id.context_key))
 
-    def test_validate(self):
+    @ddt.data(*VALID_CUSTOM_PARAMETERS)
+    def test_validate_with_valid_custom_parameters(self, custom_parameters):
         """
-        Test that if custom_parameters is empty string, a validation error is added
+        Test if all custom_parameters item are valid
         """
-        self.xblock.custom_parameters = ''
+        self.xblock.custom_parameters = custom_parameters
         validation = self.xblock.validate()
-        self.assertFalse(validation.empty)
+        self.assertEqual(validation.messages, [])
+
+    @patch('lti_consumer.lti_xblock.ValidationMessage')
+    @patch.object(Validation, 'add')
+    def test_validate_with_empty_custom_parameters(self, add_mock, mock_validation_message):
+        """
+        Test if custom_parameters is not a list, a validation error is added
+        """
+        mock_validation_message.ERROR.return_value = 'error'
+        self.xblock.custom_parameters = ''
+
+        self.xblock.validate()
+
+        add_mock.assert_called_once_with(
+            mock_validation_message('error', 'Custom Parameters must be a list'),
+        )
+
+    @ddt.data(*INVALID_CUSTOM_PARAMETERS)
+    @patch('lti_consumer.lti_xblock.ValidationMessage')
+    @patch.object(Validation, 'add')
+    def test_validate_with_invalid_custom_parameters(self, custom_parameters, add_mock, mock_validation_message):
+        """
+        Test if a custom_parameters item is not valid, a validation error is added
+        """
+        mock_validation_message.ERROR.return_value = 'error'
+        self.xblock.custom_parameters = custom_parameters
+
+        self.xblock.validate()
+
+        add_mock.assert_called_once_with(
+            mock_validation_message('error', 'Custom Parameters should be strings in "x=y" or "x=${y}" format'),
+        )
 
     def test_role(self):
         """
@@ -1594,6 +1636,17 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.addCleanup(self.mock_filter_enabled_patcher.stop)
         self.addCleanup(self.mock_database_config_enabled_patcher.stop)
 
+    @patch('lti_consumer.lti_xblock.resolve_custom_parameter_template')
+    def test_get_lti_1p3_custom_parameters(self, mock_resolve_custom_parameter_template):
+        """
+        Test that get_lti_1p3_custom_parameters returns an dictionary of custom parameters
+        """
+        mock_resolve_custom_parameter_template.return_value = ''
+        self.xblock.custom_parameters = ['test1=test', 'test2=${test}']
+
+        self.assertDictEqual(self.xblock.get_lti_1p3_custom_parameters(), {'test1': 'test', 'test2': ''})
+        mock_resolve_custom_parameter_template.assert_called_once_with(self.xblock, '${test}')
+
     @ddt.idata(product([True, False], [True, False], [True, False]))
     @ddt.unpack
     def test_get_lti_1p3_launch_data(self, pii_sharing_enabled, ask_to_send_username, ask_to_send_email):
@@ -1623,6 +1676,9 @@ class TestLtiConsumer1p3XBlock(TestCase):
         # Mock out get_pii_sharing_enabled to reduce the amount of mocking we have to do.
         self.xblock.get_pii_sharing_enabled = Mock(return_value=pii_sharing_enabled)
 
+        # Mock custom_parameters property.
+        self.xblock.get_lti_1p3_custom_parameters = Mock(return_value={})
+
         launch_data = self.xblock.get_lti_1p3_launch_data()
 
         course_key = str(self.xblock.scope_ids.usage_id.course_key)
@@ -1639,6 +1695,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
             "context_type": ["course_offering"],
             "context_title": "context_title",
             "context_label": course_key,
+            "custom_parameters": {},
         }
 
         if pii_sharing_enabled:
@@ -1656,6 +1713,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
             launch_data,
             expected_launch_data
         )
+        self.xblock.get_lti_1p3_custom_parameters.assert_called_once_with()
 
     @patch('lti_consumer.plugin.compat.get_course_by_id')
     def test_get_context_title(self, mock_get_course_by_id):


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-332

## Description

This PR adds a feature that allows the LTI consumer XBlock to send custom parameters (including dynamic custom parameters) to LTI 1.3 launches.

## Type of Change

- [x] Add get_lti_1p3_custom_parameters function to LtiConsumerXBlock class.
- [x] Add test_get_lti_1p3_custom_parameters test to TestLtiConsumer1p3XBlock class.
- [x] Modify get_lti_1p3_launch_data function on LtiConsumerXBlock class.
- [x] Add test_launch_existing_custom_parameters test to TestLti1p3LaunchGateEndpoint test case. 
- [x] Add test_launch_non_existing_custom_parameters test to TestLti1p3LaunchGateEndpoint test case.

## Testing:

- Add LTI custom params template setting:

``` 
	# Here we set the value to any module and function
	# that can be imported and returns a str.
	LTI_CUSTOM_PARAM_TEMPLATES = {
	    'test_param': 'django.utils.html:escape'
	}
```

- Run the LMS: `make dev.up.lms`.
- Run studio: `make dev.up.studio`.
- Run the frontend-app-learning mfe: `make dev.up.frontend-app-learning`.
- Install `xblock-lti-consumer` on the LMS and studio.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Add LTI consumer XBlock to the course and set up LTI 1.3 launch parameters:

```
	LTI Version: LTI 1.3
	Tool Launch URL: https://lti.tool/launch
	Tool Initiate Login URL: https://lti.tool/login
	Tool Public Key Mode: Keyset URL
	Tool Keyset URL: https://lti.tool/jwks
	Custom Parameters ["color=white", "test_param=${test_param}"] 
```

- Go to the live course and execute an LTI 1.3 launch.
- The custom parameters should be present on the https://purl.imsglobal.org/spec/lti/claim/custom claim.

## Reviewers

- [x] @Squirrel18 
- [x] @Jacatove 
- [x] @alexjmpb 
- [x] @anfbermudezme 