### PR TITLE
PADV-409: Add CCX Compatibility

### DIFF
--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -7,6 +7,7 @@ return plaintext to allow easy testing/mocking.
 
 import json
 
+from ccx_keys.locator import CCXBlockUsageLocator
 from opaque_keys.edx.keys import CourseKey
 
 from lti_consumer.lti_1p3.constants import LTI_1P3_ROLE_MAP
@@ -34,6 +35,12 @@ def _get_or_create_local_lti_config(lti_version, block_location,
     the XBlock to be the source of truth for the LTI version, which is a user-centric perspective we've adopted.
     This allows XBlock users to update the LTI version without needing to update the database.
     """
+    # Replace CCX block locator with master course block locator to allow CCX launch to work.
+    # The reason behind the change is to avoid creating a new LtiConfiguration for CCXs and
+    # reuse Master's for which its client_id is already recognized by the tool provider.
+    if isinstance(block_location, CCXBlockUsageLocator):
+        block_location = block_location.to_block_locator()
+
     # The create operation is only performed when there is no existing configuration for the block
     lti_config, _ = LtiConfiguration.objects.get_or_create(location=block_location)
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,6 +12,7 @@ XBlock
 xblock-utils
 pycryptodomex
 pyjwkest
+edx-ccx-keys                 # Opaque keys for Custom Courses.
 edx-opaque-keys[django]
 django-filter
 jsonfield

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,10 +41,14 @@ django-waffle==3.0.0
     # via edx-django-utils
 djangorestframework==3.14.0
     # via django-config-models
+edx-ccx-keys==1.2.1
+    # via -r requirements/base.in
 edx-django-utils==5.2.0
     # via django-config-models
 edx-opaque-keys[django]==2.3.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   edx-ccx-keys
 fs==2.4.16
     # via xblock
 future==0.18.3
@@ -105,6 +109,7 @@ simplejson==3.18.1
 six==1.16.0
     # via
     #   bleach
+    #   edx-ccx-keys
     #   fs
     #   pyjwkest
     #   python-dateutil

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -146,6 +146,8 @@ docutils==0.19
     # via
     #   -r requirements/test.txt
     #   readme-renderer
+edx-ccx-keys==1.2.1
+    # via -r requirements/test.txt
 edx-django-utils==5.2.0
     # via
     #   -r requirements/test.txt
@@ -153,7 +155,9 @@ edx-django-utils==5.2.0
 edx-lint==5.3.0
     # via -r requirements/test.txt
 edx-opaque-keys[django]==2.3.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   edx-ccx-keys
 filelock==3.9.0
     # via
     #   -r requirements/tox.txt
@@ -407,6 +411,7 @@ six==1.16.0
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
     #   bleach
+    #   edx-ccx-keys
     #   edx-lint
     #   fs
     #   fs-s3fs

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,3 +11,5 @@
 # Common constraints for edx repos
 -c common_constraints.txt
 
+# Use edx-platform pearson-release/olive.main version
+edx-ccx-keys==1.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,6 +59,8 @@ djangorestframework==3.14.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
+edx-ccx-keys==1.2.1
+    # via -r requirements/base.txt
 edx-django-utils==5.2.0
     # via
     #   -r requirements/base.txt
@@ -66,7 +68,9 @@ edx-django-utils==5.2.0
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
 edx-opaque-keys[django]==2.3.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-ccx-keys
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -161,6 +165,7 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   edx-ccx-keys
     #   fs
     #   pyjwkest
     #   python-dateutil

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -95,6 +95,8 @@ djangorestframework==3.14.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
+edx-ccx-keys==1.2.1
+    # via -r requirements/base.txt
 edx-django-utils==5.2.0
     # via
     #   -r requirements/base.txt
@@ -102,7 +104,9 @@ edx-django-utils==5.2.0
 edx-lint==5.3.0
     # via -r requirements/quality.in
 edx-opaque-keys[django]==2.3.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-ccx-keys
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -253,6 +257,7 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   edx-ccx-keys
     #   edx-lint
     #   fs
     #   fs-s3fs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -112,6 +112,8 @@ docopt==0.6.2
     # via coveralls
 docutils==0.19
     # via readme-renderer
+edx-ccx-keys==1.2.1
+    # via -r requirements/base.txt
 edx-django-utils==5.2.0
     # via
     #   -r requirements/base.txt
@@ -119,7 +121,9 @@ edx-django-utils==5.2.0
 edx-lint==5.3.0
     # via -r requirements/test.in
 edx-opaque-keys[django]==2.3.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-ccx-keys
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -308,6 +312,7 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   edx-ccx-keys
     #   edx-lint
     #   fs
     #   fs-s3fs


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-409

## Description

This PR adds a fix that allows the LTI consumer XBlock to work on CCXs with LTI 1.3 launches.
The LTI consumer XBlock creates a model instance of LtiConfiguration using its location, on CCXs this creates a new LtiConfiguration with a client_id that is not known to the tool provider. This fixes the LTI consumer on CCXs by using the master course counterpart XBlock location with the to_block_locator method of CCXBlockLocator to retrieve the master course LtiConfiguration models instance.

## Type of Change

- [x] Modify _get_or_create_local_lti_config API function.
- [x] Add test_retrieve_ccx_config test to TestGetOrCreateLocalLtiConfiguration class.
- [x] Modify get_lti_1p3_launch_data function on LtiConsumerXBlock class.

## Testing:

- Enable CCX on LMS and Studio.
- Run the LMS: `make dev.up.lms`.
- Run studio: `make dev.up.studio`.
- Run the frontend-app-learning mfe: `make dev.up.frontend-app-learning`.
- Install `xblock-lti-consumer` on the LMS and studio.
- Enable CCX on course advance settings.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Add LTI consumer XBlock to the course and set up LTI 1.3 launch parameters:

```
	LTI Version: LTI 1.3
	Tool Launch URL: https://lti.tool/launch
	Tool Initiate Login URL: https://lti.tool/login
	Tool Public Key Mode: Keyset URL
	Tool Keyset URL: https://lti.tool/jwks
```

- Add a CCX coach to the course and create a CCX.
- Go to the CCX live course and execute an LTI 1.3 launch.
- The launch should work without issues.

## Reviewers

- [x] @Squirrel18 
- [x] @Jacatove