### PR TITLE
PADV-411: Allow special characters on custom parameters

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -100,11 +100,12 @@ LTI_1P1_ROLE_MAP = {
     'instructor': 'Instructor',
 }
 CUSTOM_PARAMETER_SEPARATOR = '='
-CUSTOM_PARAMETER_TEMPLATE_PATTERN = r'\${ *\w+ *}'
-CUSTOM_PARAMETER_TEMPLATE_REGEX = re.compile(CUSTOM_PARAMETER_TEMPLATE_PATTERN)
+# Allow a key-pair key and value to contain any character except "=".
 CUSTOM_PARAMETER_REGEX = re.compile(
-    rf'^( *\w+ *{CUSTOM_PARAMETER_SEPARATOR} *(\w+|{CUSTOM_PARAMETER_TEMPLATE_PATTERN}) *)$',
+    rf'^([^{CUSTOM_PARAMETER_SEPARATOR}]+{CUSTOM_PARAMETER_SEPARATOR}[^{CUSTOM_PARAMETER_SEPARATOR}]+)$',
 )
+# Catch a value enclosed by ${}, the value enclosed can contain any charater except "=".
+CUSTOM_PARAMETER_TEMPLATE_REGEX = re.compile(r'^(\${[^%s]+})$' % CUSTOM_PARAMETER_SEPARATOR)
 
 
 def parse_handler_suffix(suffix):
@@ -651,7 +652,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         if not all(map(CUSTOM_PARAMETER_REGEX.match, data.custom_parameters)):
             _ = self.runtime.service(self, 'i18n').ugettext
             validation.add(ValidationMessage(ValidationMessage.ERROR, str(
-                _('Custom Parameters should be strings in "x=y" or "x=${y}" format'),
+                _('Custom Parameters should be strings in "x=y" format.'),
             )))
 
         # keyset URL and public key are mutually exclusive

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -38,14 +38,6 @@ HTML_ERROR_MESSAGE = '<h3 class="error_message">'
 HTML_LAUNCH_MODAL_BUTTON = 'btn-lti-modal'
 HTML_LAUNCH_NEW_WINDOW_BUTTON = 'btn-lti-new-window'
 HTML_IFRAME = '<iframe'
-VALID_CUSTOM_PARAMETERS = (
-    ['x=y'], ['  x  =  y  '], ['x=${y}'], ['  x  =  ${y} '], ['x=${  y  }'],
-    ['x=y', 'x=${y}', '  x  =  y  ', '  x  =  ${y} ', 'x=${  y  }'],
-)
-INVALID_CUSTOM_PARAMETERS = (
-    ['x'], ['x='], ['x=y y'], ['x={y}'], ['x={y'], ['x=y}'], ['x=*'], ['=y'], ['x x=y'], ['*=y'],
-    ['x', 'x=', 'x=y y', 'x={y}', 'x={y', 'x=y}', 'x=*', '=y', 'x x=y', '*=y'],
-)
 
 
 class TestLtiConsumerXBlock(TestCase):
@@ -148,7 +140,10 @@ class TestProperties(TestLtiConsumerXBlock):
         """
         self.assertEqual(self.xblock.context_id, str(self.xblock.scope_ids.usage_id.context_key))
 
-    @ddt.data(*VALID_CUSTOM_PARAMETERS)
+    @ddt.data(
+        ['x=y'], [' x x = y y '], ['x= '], [' =y'], [' = '],
+        ['x=y', ' x x = y y ', 'x= ', ' =y', ' = '],
+    )
     def test_validate_with_valid_custom_parameters(self, custom_parameters):
         """
         Test if all custom_parameters item are valid
@@ -172,7 +167,7 @@ class TestProperties(TestLtiConsumerXBlock):
             mock_validation_message('error', 'Custom Parameters must be a list'),
         )
 
-    @ddt.data(*INVALID_CUSTOM_PARAMETERS)
+    @ddt.data(['x'], ['x='], ['=y'], ['x==y'], ['x', 'x=', '=y', 'x==y'])
     @patch('lti_consumer.lti_xblock.ValidationMessage')
     @patch.object(Validation, 'add')
     def test_validate_with_invalid_custom_parameters(self, custom_parameters, add_mock, mock_validation_message):
@@ -185,7 +180,7 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.validate()
 
         add_mock.assert_called_once_with(
-            mock_validation_message('error', 'Custom Parameters should be strings in "x=y" or "x=${y}" format'),
+            mock_validation_message('error', 'Custom Parameters should be strings in "x=y" format.'),
         )
 
     def test_role(self):


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-411

## Description

This PR adds a feature that allows the LTI consumer XBlock to have custom parameters (including dynamic custom parameters) with special characters (!#$%&()*+,-.:;<>?@[]^{|}~).

## Type of Change

- [x] Add CUSTOM_PARAMETER_CHARS_SET constant.
- [x] Modify CUSTOM_PARAMETER_REGEX constant.
- [x] Modify CUSTOM_PARAMETER_TEMPLATE_REGEX constant.
- [x] Remove CUSTOM_PARAMETER_TEMPLATE_PATTERN constant.
- [x] Remove VALID_CUSTOM_PARAMETERS constant.
- [x] Remove INVALID_CUSTOM_PARAMETERS constant.
- [x] Modify test_validate_with_valid_custom_parameters test on TestLtiConsumerXBlock test case. 
- [x] Modify test_validate_with_invalid_custom_parameters test on TestLtiConsumerXBlock test case.

## Testing:

- Add LTI custom params template setting:

``` 
	# Here we set the value to any module and function
	# that can be imported and returns a str.
	LTI_CUSTOM_PARAM_TEMPLATES = {
	    'TestC123!#$%&()*+,-.:;<>?@[]^{|}~}': 'django.utils.html:escape'
	}
```

- Run the LMS: `make dev.up.lms`.
- Run studio: `make dev.up.studio`.
- Run the frontend-app-learning mfe: `make dev.up.frontend-app-learning`.
- Install `xblock-lti-consumer` on the LMS and studio.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Add LTI consumer XBlock to the course and set up LTI 1.3 launch parameters:

```
	LTI Version: LTI 1.3
	Tool Launch URL: https://lti.tool/launch
	Tool Initiate Login URL: https://lti.tool/login
	Tool Public Key Mode: Keyset URL
	Tool Keyset URL: https://lti.tool/jwks
	Custom Parameters ["TestA123!#$%&()*+,-.:;<>?@[]^{|}~=TestA123!#$%&()*+,-.:;<>?@[]^{|}~", "TestC123!#$%&()*+,-.:;<>?@[]^{|}~=${TestC123!#$%&()*+,-.:;<>?@[]^{|}~}"] 
```

- Go to the live course and execute an LTI 1.3 launch.
- The custom parameters should be present on the https://purl.imsglobal.org/spec/lti/claim/custom claim.

## Reviewers

- [x] @Squirrel18 
- [x] @Jacatove 
 