### PR TITLE
PADV-412: Add LTI 1.3 re-usable configuration ADR

### DIFF
--- a/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
+++ b/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
@@ -59,6 +59,14 @@ Note: We aren't completely clear on what might need to change appart from
 _get_lti_1p3_consumer and get_lti_1p3_launch_info in xblock-lti-consumer
 to allow the use of LTI 1.3 external configurations.
 
+We also need to modify the LtiConfiguration model to sync the changes on
+the config store field and external ID field on all CCX XBlocks related to
+the master courser XBlock beign modified, this could be achieved by two method,
+first by copying the config store and external ID values when a CCX XBlock
+LtiConfiguration is beign created and by also sync changes from the master
+LtiConfiguration with a post save signal, in that signal we can iterate over
+any CCX LtiConfiguration related and sync the config ID and external ID values.
+
 Changes on lti_store
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
+++ b/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
@@ -55,18 +55,21 @@ Changes on xblock-lti-consumer
 - Modify the get_lti_1p3_launch_info function to show the values from the
   external configuration on the author view.
 
+Note: We aren't completely clear on what might need to change appart from
+_get_lti_1p3_consumer and get_lti_1p3_launch_info in xblock-lti-consumer
+to allow the use of LTI 1.3 external configurations.
+
 Changes on lti_store
 ~~~~~~~~~~~~~~~~~~~~
 
-- Add an LTI 1.3 external configuration model to lti_store with fields for the
+- Add LTI 1.3 fields to lti_store ExternalLtiConfiguration model for the
   client ID, private key, private key ID, public key or keyset URL, and
-  optionally the deployment id.
-- Add the LTI 1.3 external configuration model to the admin view and display
-  the name, slug, token URL, keyset URL, and filter key.
+  deployment id.
+- Add LTI 1.3 has a version choice on ExternalLtiConfiguration model.
+- Add a clean method to ExternalLtiConfiguration model to avoid mixing LTI 1.1
+  and LTI 1.3 fields.
 - Add an access token view to lti_store for LTI 1.3 external configurations.
 - Add a keyset view to lti_store for LTI 1.3 external configurations.
-- Modify the lti_store pipeline GetLtiConfigurations to also include LTI 1.3
-  external configurations in the result.
 
 Note: The private key ID on the LTI 1.3 external configuration model can be an
 auto-generated uuid4, just as how it's already being done on the

--- a/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
+++ b/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
@@ -1,0 +1,77 @@
+PADV-412: LTI 1.3 Pluggable and re-usable LTI configuration
+===========================================================
+
+Status
+======
+
+Proposal
+
+Context
+=======
+
+In this discovery, we will describe a possible approach to add LTI 1.3 support
+for pluggable and re-usable LTI configurations on the lti_store plugin and
+xblock-lti-consumer XBlock.
+
+The #239 issue on xblock-lti-consumer added support for LTI 1.1 pluggability,
+on the Open edX roadmap ticket #143, related to the feature of external
+pluggable LTI configuration, there was planned implementation for LTI 1.3
+support, according to comments on #210, progress on this effort has been
+stopped, currently, the remaining efforts to reach LTI 1.3 support are:
+
+- Expand the plugin support to allow storing and retrieval of LTI 1.3
+  configuration
+- Update the LTI Consumer to use the configuration from the filter pipeline to
+  load an external LTI tool using LTI 1.3 spec
+- Remove XBlock dependencies from LTI 1.3 launches (features related to LTI 1.3
+  authentication, for example, the keyset URL and the token URL).
+
+This feature will allow us to eliminate the need to configure multiple LTI
+tools for each LTI 1.3 consumer XBlock and allow LTI 1.3 consumer XBlock to
+share a common configuration, this will also allow for multi-tenancy model
+compatibility on the platform. We will also be able to use CCX XBlocks that use
+LTI 1.3.
+
+General Approach
+===============
+
+We will need to modify the lti_store plugin and xblock-lti-consumer to include
+these changes:
+
+Changes on xblock-lti-consumer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Modify xblock-lti-consumer to allow setting the
+  "LTI Reusable Configuration ID" field and add the "Reusable Configuration"
+  option to the "Configuration Type" field on XBlocs using LTI 1.3 version.
+- Modify the _get_lti_1p3_consumer method on the LTI configuration model to use
+  the values from the external configuration when enabled.
+- Modify the get_lti_1p3_launch_info function to show the values from the
+  external configuration on the author view.
+
+Changes on lti_store
+~~~~~~~~~~~~~~~~~~~~
+
+- Add an LTI 1.3 external configuration model to lti_store with fields for the
+  client ID, private key, private key ID, public key or keyset URL, and
+  optionally the deployment id.
+- Add the LTI 1.3 external configuration model to the admin view and display
+  the name, slug, token URL, keyset URL, and filter key.
+- Add an access token view to lti_store for LTI 1.3 external configurations.
+- Add a keyset view to lti_store for LTI 1.3 external configurations.
+- Modify the lti_store pipeline GetLtiConfigurations to also include LTI 1.3
+  external configurations in the result.
+
+Note: The private key ID on the LTI 1.3 external configuration model can be an
+auto-generated uuid4, just as how it's already being done on the
+_generate_lti_1p3_keys_if_missing method on the LtiConfiguration model in
+xblock-lti-consumer.
+
+References
+==========
+
+- Open edX Roadmap - Central Management of LTI Configuration: https://github.com/openedx/platform-roadmap/issues/143
+- Pluggable and re-usable LTI configuration ADR: https://github.com/openedx/xblock-lti-consumer/blob/469d47dd2b3f1f742da429a64108b5a4ff03165d/docs/decisions/0006-pluggable-lti-configuration.rst
+- Pluggable/reusable LTI configuration: https://github.com/openedx/xblock-lti-consumer/pull/210
+- Support for external LTI configurations using openedx-filters: https://github.com/openedx/xblock-lti-consumer/pull/239
+- Openedx LTI Store: https://github.com/open-craft/openedx-ltistore

--- a/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
+++ b/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
@@ -26,6 +26,9 @@ has been stopped, currently, the remaining efforts to reach LTI 1.3 support are:
 - Remove XBlock dependencies from LTI 1.3 launches (features related to LTI 1.3
   authentication, for example, the keyset URL and the token URL).
 
+Why do we need this?
+====================
+
 This feature is important because it will allow us to eliminate the need to
 configure multiple LTI tools for each LTI 1.3 consumer XBlock (course authors
 may not have access to deploy LTI 1.3 tools) and allow LTI 1.3 consumer XBlock

--- a/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
+++ b/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
@@ -13,11 +13,11 @@ In this discovery, we will describe a possible approach to add LTI 1.3 support
 for pluggable and re-usable LTI configurations on the lti_store plugin and
 xblock-lti-consumer XBlock.
 
-The #239 issue on xblock-lti-consumer added support for LTI 1.1 pluggability,
-on the Open edX roadmap ticket #143, related to the feature of external
-pluggable LTI configuration, there was planned implementation for LTI 1.3
-support, according to comments on #210, progress on this effort has been
-stopped, currently, the remaining efforts to reach LTI 1.3 support are:
+The #239 issue on xblock-lti-consumer [4]_ added support for LTI 1.1
+pluggability, on the Open edX roadmap ticket #143 [1]_, related to the feature
+of external pluggable LTI configuration, there was planned implementation for
+LTI 1.3 support, according to comments on #210 [3]_, progress on this effort
+has been stopped, currently, the remaining efforts to reach LTI 1.3 support are:
 
 - Expand the plugin support to allow storing and retrieval of LTI 1.3
   configuration
@@ -26,11 +26,14 @@ stopped, currently, the remaining efforts to reach LTI 1.3 support are:
 - Remove XBlock dependencies from LTI 1.3 launches (features related to LTI 1.3
   authentication, for example, the keyset URL and the token URL).
 
-This feature will allow us to eliminate the need to configure multiple LTI
-tools for each LTI 1.3 consumer XBlock and allow LTI 1.3 consumer XBlock to
-share a common configuration, this will also allow for multi-tenancy model
-compatibility on the platform. We will also be able to use CCX XBlocks that use
-LTI 1.3.
+This feature is important because it will allow us to eliminate the need to
+configure multiple LTI tools for each LTI 1.3 consumer XBlock (course authors
+may not have access to deploy LTI 1.3 tools) and allow LTI 1.3 consumer XBlock
+to share a common configuration, this will also allow for multi-tenancy model
+compatibility on the platform and ease the maintenance of courses that heavily
+depend on many LTI 1.3 XBlocks. We will also be able to use CCX XBlocks that
+use LTI 1.3 since the CCX XBlocks would not have a separate configuration from
+its master course counterpart.
 
 General Approach
 ===============
@@ -70,8 +73,8 @@ xblock-lti-consumer.
 References
 ==========
 
-- Open edX Roadmap - Central Management of LTI Configuration: https://github.com/openedx/platform-roadmap/issues/143
-- Pluggable and re-usable LTI configuration ADR: https://github.com/openedx/xblock-lti-consumer/blob/469d47dd2b3f1f742da429a64108b5a4ff03165d/docs/decisions/0006-pluggable-lti-configuration.rst
-- Pluggable/reusable LTI configuration: https://github.com/openedx/xblock-lti-consumer/pull/210
-- Support for external LTI configurations using openedx-filters: https://github.com/openedx/xblock-lti-consumer/pull/239
-- Openedx LTI Store: https://github.com/open-craft/openedx-ltistore
+.. [1] #143 Open edX Roadmap - Central Management of LTI Configuration: https://github.com/openedx/platform-roadmap/issues/143
+.. [2] Pluggable and re-usable LTI configuration ADR: https://github.com/openedx/xblock-lti-consumer/blob/469d47dd2b3f1f742da429a64108b5a4ff03165d/docs/decisions/0006-pluggable-lti-configuration.rst
+.. [3] #210 Pluggable/reusable LTI configuration: https://github.com/openedx/xblock-lti-consumer/pull/210
+.. [4] #239 Support for external LTI configurations using openedx-filters: https://github.com/openedx/xblock-lti-consumer/pull/239
+.. [5] Openedx LTI Store: https://github.com/open-craft/openedx-ltistore

--- a/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
+++ b/docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst
@@ -84,3 +84,4 @@ References
 .. [3] #210 Pluggable/reusable LTI configuration: https://github.com/openedx/xblock-lti-consumer/pull/210
 .. [4] #239 Support for external LTI configurations using openedx-filters: https://github.com/openedx/xblock-lti-consumer/pull/239
 .. [5] Openedx LTI Store: https://github.com/open-craft/openedx-ltistore
+.. [6] #273 Remove XBlock location dependencies from LTI 1.3 launches: https://github.com/openedx/xblock-lti-consumer/issues/273


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-412

## Description

This PR adds an ADR document where we will address the discovery issue on the ticket PADV-412, the document contains information on LTI 1.3 re-usable configuration feature. these are a description of a general approach to achieving this. We will use this ADR to discuss the LTI 1.3 re-usable configuration feature implementation.

## Type of Change

- Add ADR /docs/decisions/0008-lti-1p3-puggable-lti-configuration.rst with discovery on LTI 1.3 re-usable configuration.

## Reviewers

- [x] @anfbermudezme 
- [x] @Squirrel18