### PR TITLE
PADV-428: LTI 1.3 advantage services CCX compatibility

### DIFF
--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -7,7 +7,6 @@ return plaintext to allow easy testing/mocking.
 
 import json
 
-from ccx_keys.locator import CCXBlockUsageLocator
 from opaque_keys.edx.keys import CourseKey
 
 from lti_consumer.lti_1p3.constants import LTI_1P3_ROLE_MAP
@@ -35,12 +34,6 @@ def _get_or_create_local_lti_config(lti_version, block_location,
     the XBlock to be the source of truth for the LTI version, which is a user-centric perspective we've adopted.
     This allows XBlock users to update the LTI version without needing to update the database.
     """
-    # Replace CCX block locator with master course block locator to allow CCX launch to work.
-    # The reason behind the change is to avoid creating a new LtiConfiguration for CCXs and
-    # reuse Master's for which its client_id is already recognized by the tool provider.
-    if isinstance(block_location, CCXBlockUsageLocator):
-        block_location = block_location.to_block_locator()
-
     # The create operation is only performed when there is no existing configuration for the block
     lti_config, _ = LtiConfiguration.objects.get_or_create(location=block_location)
 

--- a/lti_consumer/tests/unit/test_api.py
+++ b/lti_consumer/tests/unit/test_api.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 import ddt
 
-from ccx_keys.locator import CCXBlockUsageLocator
 from Cryptodome.PublicKey import RSA
 from django.test.testcases import TestCase
 from edx_django_utils.cache import get_cache_key
@@ -174,34 +173,6 @@ class TestGetOrCreateLocalLtiConfiguration(TestCase):
 
         # Check if the object was created
         self.assertEqual(LtiConfiguration.objects.all().count(), 1)
-        self.assertEqual(lti_config_retrieved, lti_config)
-
-    @patch('lti_consumer.api.isinstance')
-    def test_retrieve_ccx_config(self, mock_isinstance):
-        """
-        Check if the API retrieves a model using the master course location of a CCX location.
-        """
-        master_location = 'block-v1:course+test+2020+type@problem+block@test'
-        ccx_location = Mock(return_value='ccx-block-v1:course+test+2020+type@problem+block@test')
-        ccx_location.to_block_locator.return_value = master_location
-        mock_isinstance.return_value = True
-
-        # Create master course location lti_config.
-        lti_config = LtiConfiguration.objects.create(
-            location=master_location,
-        )
-
-        # Get CCX location lti_config.
-        lti_config_retrieved = _get_or_create_local_lti_config(
-            lti_version="",
-            block_location=ccx_location,
-        )
-
-        # Check CCX attribute was inspected on location.
-        mock_isinstance.assert_called_once_with(ccx_location, CCXBlockUsageLocator)
-        # Check CCX block locator was trnasformed to block locator.
-        ccx_location.to_block_locator.assert_called_once_with()
-        # Check CCX lti_config is equal to master course lti_config.
         self.assertEqual(lti_config_retrieved, lti_config)
 
     def test_update_lti_version(self):

--- a/lti_consumer/tests/unit/test_utils.py
+++ b/lti_consumer/tests/unit/test_utils.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock, patch
 
 import ddt
 from django.test.testcases import TestCase
+from opaque_keys.edx.keys import UsageKey
+from ccx_keys.locator import CCXBlockUsageLocator
 
 from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from lti_consumer.utils import (
@@ -12,6 +14,7 @@ from lti_consumer.utils import (
     get_lti_1p3_launch_data_cache_key,
     cache_lti_1p3_launch_data,
     get_data_from_cache,
+    is_ccx_location,
 )
 
 
@@ -113,3 +116,27 @@ class TestCacheUtilities(TestCase):
             self.assertEqual(value, "value")
         else:
             self.assertIsNone(value)
+
+
+class TestCCXUtilities(TestCase):
+    """
+    Tests for the CCX utilities in the utils module.
+    """
+
+    def test_is_ccx_location_with_ccx_location(self):
+        """
+        Test is_ccx_location function with CCX location.
+        """
+        location = CCXBlockUsageLocator.from_string('ccx-block-v1:course+test+2020+ccx@1+type@problem+block@test')
+
+        # Check LTI configuration with CCX location returns True.
+        self.assertEqual(is_ccx_location(location), True)
+
+    def test_is_ccx_location_without_ccx_location(self):
+        """
+        Test is_ccx_location function without CCX location.
+        """
+        location = UsageKey.from_string('block-v1:course+test+2020+type@problem+block@test')
+
+        # Check LTI configuration without CCX location returns False.
+        self.assertEqual(is_ccx_location(location), False)

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from edx_django_utils.cache import get_cache_key, TieredCache
+from ccx_keys.locator import CCXBlockUsageLocator
 
 from lti_consumer.plugin.compat import (
     get_external_config_waffle_flag,
@@ -319,3 +320,10 @@ def check_token_claim(token, claim_key, expected_value=None, invalid_claim_error
     if expected_value and claim_value != expected_value:
         msg = invalid_claim_error_msg if invalid_claim_error_msg else f"The claim {claim_key} value is invalid."
         raise InvalidClaimValue(msg)
+
+
+def is_ccx_location(location):
+    """
+    Check if the block location is from a CCX.
+    """
+    return isinstance(location, CCXBlockUsageLocator)


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-428

## Description

This PR adds a fix that allows the LTI consumer XBlock to work on CCXs with LTI 1.3 advantage services (AGS, names and roles service).
To fix this, we removed the previously merge partial fix on CCX from #3 and replaced it by modifying the LtiConfiguration model to copy the private key, private key ID, public JWK and client ID from the master CCX block LtiConfiguration instance,
to make sure LTI 1.3 launches on CCX work by using the same client ID and keys, while having it's own LtiConfiguration, this is required to allow advantage services such has AGS, since these services depend on endpoints that are related to each LtiConfiguration related to the location the score is being set.

## Type of Change

- [x] Remove changes from #3 PR.
- [x] Add is_ccx_location property to LtiConfiguration model.
- [x] Add ccx_master_configuration property to LtiConfiguration model.
- [x] Add custom save method to LtiConfiguration model.
- [x] Modify _generate_lti_1p3_keys_if_missing method on LtiConfiguration model to allow copying keys and client ID from master CCX block.

## Testing:

- Enable CCX on LMS and Studio.
- Run the LMS: `make dev.up.lms`.
- Run studio: `make dev.up.studio`.
- Run the frontend-app-learning mfe: `make dev.up.frontend-app-learning`.
- Install `xblock-lti-consumer` on the LMS and studio.
- Enable CCX on course advance settings.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Add LTI consumer XBlock to the course and set up LTI 1.3 launch parameters:

```
	LTI Version: LTI 1.3
	Tool Launch URL: https://lti.tool/launch
	Tool Initiate Login URL: https://lti.tool/login
	Tool Public Key Mode: Keyset URL
	Tool Keyset URL: https://lti.tool/jwks
```

- Add a CCX coach to the course and create a CCX.
- Go to the CCX live course and execute an LTI 1.3 launch.
- The launch should work without issues.
- On the launch view, request for a score update using AGS.
- The score update request should work and a new LtiAgsScore model instance should be created.

## Reviewers

- [ ] @Squirrel18 
- [x] @anfbermudezme 
- [x] @alexjmpb 
