### PR TITLE
PADV-505: LTI reusable configuration ID field on studio

### DIFF
--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -67,7 +67,7 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
 
 
     /**
-     * Return fields that should be hidden based on the selected config type. 
+     * Return fields that should be hidden based on the selected config type.
      *
      *  new - Show all the LTI 1.1/1.3 config fields
      *  database - Do not show the LTI 1.1/1.3 config fields
@@ -125,6 +125,9 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
     function toggleLtiFields() {
         const configFields = lti1P1FieldList.concat(lti1P3FieldList);
         const hiddenFields = new Set();
+
+        // Include the external_config field into configFields list.
+        configFields.push("external_config")
 
         // Start with the assumption that all configFields should be visible. After that, we whittle down the
         // list of visible fields based on the values of those fields.


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-505

## Description

This PR adds a fix to the behavior of the fields in studio, specifically a bug that kept the external_config field hidden after a different config_type value other than the "database" value was chosen.


## Type of Change

- [x] Update lti_consumer/static/js/xblock_studio_view.js toggleLtiFields function.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Run studio: `make dev.up.studio`.
- Install `xblock-lti-consumer` on the LMS and studio.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Enable the external config feature by creating a course waffle flag in the [admin page](http://localhost:18010/admin/waffle_utils/waffleflagcourseoverridemodel/)
    FLAG: lti_consumer.enable_external_config_filter
    Course: <your course id>
    Force: ON
    Enabled
- Add LTI consumer XBlock to the course.
- The external_config field should hide/show correctly depending on the config_type chosen.

## Reviewers

- [x] @alexjmpb 
- [x] @sergivalero20 
