### PR TITLE
PADV-506: Fix/Improve CCX LTI configuration compatibility

### DIFF
--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -1,13 +1,13 @@
 """
 Utility functions for LTI Consumer block
 """
+import copy
 import logging
 from importlib import import_module
 from urllib.parse import urlencode
 
 from django.conf import settings
 from edx_django_utils.cache import get_cache_key, TieredCache
-from ccx_keys.locator import CCXBlockUsageLocator
 
 from lti_consumer.plugin.compat import (
     get_external_config_waffle_flag,
@@ -322,8 +322,25 @@ def check_token_claim(token, claim_key, expected_value=None, invalid_claim_error
         raise InvalidClaimValue(msg)
 
 
-def is_ccx_location(location):
+def model_to_dict(model_object, exclude=None):
     """
-    Check if the block location is from a CCX.
+    Get dictionary from model object.
+
+    This function will create a copy of a model object in a dictionary,
+    with all private and excluded fields removed.
     """
-    return isinstance(location, CCXBlockUsageLocator)
+    if not exclude:
+        exclude = []
+
+    try:
+        # Copy model object fields.
+        object_fields = copy.deepcopy(model_object.__dict__)
+
+        # Remove private and excluded fields.
+        for key in list(object_fields):
+            if key.startswith('_') or key in exclude:
+                object_fields.pop(key, None)
+
+        return object_fields
+    except (AttributeError, TypeError):
+        return {}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-506

## Description

This PR adds compatibility fix for CCXs and external reusable configurations to the LTI consumer XBlock. This also includes changes to previously added fixes for CCXs using the LTI consumer XBlock. This changes allow the LTI consumer XBlock to sync values from the main CCX LTI configuration model to all of it's children CCX LTI configurations and vice versa.

- [x] Remove previous CCX fixes.
- [x] Add LtiConfiguration sync_configurations method.
- [x] Add model_to_dict function to utils module.
- [x] Modify LtiConfiguration save method.
- [x] Include unit tests for all added and modified code.

## Testing

1. Install and configure xblock-lti-consumer
2. Create a course and add a LTI consumer XBlock.
3. Create a CCX of the previously created course. 
4. Launch the CCX course unit with the LTI consumer XBlock.
5. Go to http://localhost:18000/admin/lti_consumer/lticonfiguration/.
6. Both the main LTI configuration and it's children CCX configuration should have the same values.
7. Update any value on the main LTI configuration.
8. Go to the children CCX LTI configuration.
9. The values from the main LTI configuration should be reflected.
10. Delete both LTI configurations.
11. Launch the CCX course unit with the LTI consumer XBlock.
12. Launch the course unit with the main LTI consumer XBlock.
13. Go back to the LTI configuration admin and search for both newly created configurations.
14. Both LTI configurations values should be synced.

## Reviewers

- [ ] @squirrel18
- [ ] @alexjmpb
