### PR TITLE
PADV-1246: Enable external configuration for all courses

### DIFF
--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -20,18 +20,6 @@ log = logging.getLogger(__name__)
 # Namespace
 WAFFLE_NAMESPACE = 'lti_consumer'
 
-# Course Waffle Flags
-# .. toggle_name: lti_consumer.enable_external_config_filter
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enables fetching of LTI configurations from external
-#    sources like plugins using openedx-filters mechanism.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2022-03-31
-# .. toggle_tickets: https://github.com/openedx/xblock-lti-consumer/pull/239
-# .. toggle_warning: None.
-ENABLE_EXTERNAL_CONFIG_FILTER = 'enable_external_config_filter'
-
 # .. toggle_name: lti_consumer.enable_external_user_id_1p1_launches
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -55,15 +43,6 @@ ENABLE_EXTERNAL_USER_ID_1P1_LAUNCHES = 'enable_external_user_id_1p1_launches'
 # .. toggle_creation_date: 2022-06-29
 # .. toggle_warning: None.
 ENABLE_DATABASE_CONFIG = 'enable_database_config'
-
-
-def get_external_config_waffle_flag():
-    """
-    Import and return Waffle flag for enabling external LTI configuration.
-    """
-    # pylint: disable=import-error,import-outside-toplevel
-    from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
-    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_CONFIG_FILTER}', __name__)
 
 
 def get_external_user_id_1p1_launches_waffle_flag():

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from edx_django_utils.cache import get_cache_key, TieredCache
 
 from lti_consumer.plugin.compat import (
-    get_external_config_waffle_flag,
     get_external_user_id_1p1_launches_waffle_flag,
     get_database_config_waffle_flag,
 )
@@ -195,16 +194,6 @@ def resolve_custom_parameter_template(xblock, template):
         return template
 
     return template_value
-
-
-def external_config_filter_enabled(course_key):
-    """
-    Returns True if external config filter is enabled for the course via Waffle Flag.
-
-    Arguments:
-        course_key (opaque_keys.edx.locator.CourseLocator): Course Key
-    """
-    return get_external_config_waffle_flag().is_enabled(course_key)
 
 
 def external_user_id_1p1_launches_enabled(course_key):


### PR DESCRIPTION
## Ticket 

https://agile-jira.pearson.com/browse/PADV-1246

## Description

This PR enables the use of external configurations on all courses, this is achieved by removing the `lti_consumer.enable_external_config_filter` waffle flag and all the code related to it, this waffle flag was required per course to enable this feature.

## Type of Change

- [x] Remove the `lti_consumer.enable_external_config_filter` waffle flag and all it's related code.
- [x] Update all related unit tests.

## Testing

1. Install and configure xblock-lti-consumer
2. Create a course and add a LTI 1.3 consumer XBlock.
3. The XBlock should allow you by default to choose "Reusable Configuration", in the "Configuration Type" field.

## Reviewers

- [x] @alexjmpb 
- [x] @anfbermudezme 
