### PR TITLE
PADV-1778:  Fix PII consent dialog

### DIFF
--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -133,14 +133,14 @@ function LtiConsumerXBlock(runtime, element) {
                 // Show the button that triggered the event, i.e. the launch button.
                 triggerElement.show();
                 $dialog_container.remove()
-                $('body').append('<h1>Confirm Dialog Result: <i>Yes</i></h1>');
+                $('body').append('<h1 style="display:none;">Confirm Dialog Result: <i>Yes</i></h1>');
                 def.resolve("OK");
             })
             $dialog_container.find('#cancel-button').click(function () {
                 // Hide the button that triggered the event, i.e. the launch button.
                 triggerElement.show()
                 $dialog_container.remove()
-                $('body').append('<h1>Confirm Dialog Result: <i>No</i></h1>');
+                $('body').append('<h1 style="display:none;">Confirm Dialog Result: <i>No</i></h1>');
                 def.resolve("Cancel");
             })
             return def.promise();


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1778

## Description

This PR adds a fix to the LTI Consumer XBlock PII consent dialog. Currently after the user clicks on the "Ok" or "Cancel" button of the PII consent dialog, a h1 element with the text "Confirm Dialog Result: <i>Yes</i>" or "Confirm Dialog Result: <i>Yes</i>" is added to the body element, this element shouldn't be visible since it's only use to resolve a promise after the button is clicked.

## Type of Change

- [x] Hide element created after PII consent dialog is confirmed or cancelled.

## Testing:

1. Make sure the edx-platform version used has this commit: https://github.com/Pearson-Advance/edx-platform/commit/44d1c5282d97e92b15bd204eea6cb3bac754a020
2. Add a global status message to the LMS: https://localhost:18000/admin/status/globalstatusmessage/
1. Install and configure `xblock-lti-consumer`
3. Enable PII on the course you would use for testing: https://localhost:18000/admin/lti_consumer/courseallowpiisharinginltiflag/
4. Add a LTI 1.1 or 1.3 Consumer XBlock to the course.
5. Set "Request user's username" or "Request user's email" to True on the LTI Consumer XBlock.
6. Go to the course and try to execute the LTI launch.
7. Click on the "Ok" or "Cancel" button of the PII consent dialog.
8. There should not be any "Confirm Dialog Result: <i>Yes</i>" or "Confirm Dialog Result: <i>Yes</i>" element.

## Screenshots

![Before](https://github.com/user-attachments/assets/e6933a75-8208-468e-ae1b-ba8ff525c7e7)
![After](https://github.com/user-attachments/assets/32e64cce-0b82-4494-8979-664aab31327d)
