### PR TITLE
PADV-1231 - Remove leading or trailing spaces in lti launch parameters.

### DIFF
--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -308,6 +308,15 @@ class LtiConsumer1p1:
             'Content-Type': 'application/x-www-form-urlencoded',
         }
 
+        # This block removes any leading or trailing spaces in lti parameters.
+        # We are currently experiencing a launch issue with the Measure UP LTI integration (MUP)
+        # due to some courses having leading or trailing spaces in their names.
+        # We decided to handle this from our side to avoid launch request issues
+        # and due to lack of coordination and communication with the MUP team to fix this from their side.
+        for lti_parameter, lti_parameter_value in lti_parameters.items():
+            if isinstance(lti_parameter_value, str):
+                lti_parameters[lti_parameter] = lti_parameter_value.strip()
+
         oauth_signature = get_oauth_request_signature(
             self.oauth_key,
             self.oauth_secret,


### PR DESCRIPTION
## Description:

This PR adds a hot-fix that removes leading or trailing spaces in the LTI launch parameters. We are currently having an issue with the Measure UP integration because some courses have these spaces on their names. We decided to implement this change on our side with the long term plan for the MUP team to implement any necessary changes and also due to time constraints and to fix the production integration.

## Notes:

- I have tested this directly in the LMS debug pod and have used this component to test the hot-fix: https://certprepcourseware.pearson.com/learning/course/ccx-v1:VUE+9780137955268+2023+ccx@1777/ccx-block-v1:VUE+9780137955268+2023+ccx@1777+type@sequential+block@073610babe9e4ccb85c3ea8e7293d6ee/ccx-block-v1:VUE+9780137955268+2023+ccx@1777+type@vertical+block@baa34b10257d471194a9cfc9899628aa
- We will try to see if this change may be accepted on upstream so we don't have to maintain it by ourselves.

## Reviewers:

- [x] @kuipumu 