### PR TITLE
PADV-2191 feat: add launched attribute to the xblock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: ['3.8']
         toxenv: [py38-django32, py38-django40, quality]
 

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -583,6 +583,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         default=False,
         scope=Scope.settings
     )
+    launched = Boolean(
+        help=_("Whether the LTI tool has been launched"),
+        default=False,
+        scope=Scope.user_state
+    )
 
     # Possible editable fields
     editable_field_names = (
@@ -1231,6 +1236,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         }
         track_event('xblock.launch_request', event)
 
+        self.launched = True
+
         loader = ResourceLoader(__name__)
         context = self._get_context_for_template()
         context.update({'lti_parameters': lti_parameters})
@@ -1714,3 +1721,20 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         xblock_body["content_type"] = "LTI Consumer"
 
         return xblock_body
+
+    def update_launched_for_1p3(self, user):
+        """
+        Updates the state of the LTI 1.3 launch for the given user.
+
+        This method performs the following actions:
+        1. Rebinds the no-auth module to the specified user using the runtime's
+           'rebind_user' service.
+        2. Sets the `launched` attribute to True, indicating that the LTI 1.3
+           launch has been successfully completed for the user.
+
+        Args:
+            user: The user object to which the no-auth module should be rebound.
+        """
+        self.runtime.service(self, 'rebind_user').rebind_noauth_module_to_user(self, user)
+        self.launched = True
+        self.save()

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -299,6 +299,11 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         }
         track_event('xblock.launch_request', event)
 
+        # update the launched attribute of the block for the user for LTI 1.3
+        user = compat.get_user_from_external_user_id(launch_data.external_user_id)
+        block = compat.load_block_as_user(lti_config.location)
+        block.update_launched_for_1p3(user)
+
         return render(request, 'html/lti_1p3_launch.html', context)
     except Lti1p3Exception as exc:
         resource_link_id = launch_data.resource_link_id


### PR DESCRIPTION
## Description

This PR adds a new attribute to the LTI Xblock, to identify if the block in a course in the LMS was launched by a user.

## How to test

1. Using devstack, install the LTI Xblock with this branch ``PADV-2191``
2. Go to Studio and add a new LTI Consumer Xblock, in Advanced Component
3. To set up the component, see this instructions [Testing LTI 1.1](https://github.com/Pearson-Advance/xblock-lti-consumer/tree/pearson-release/olive.main?tab=readme-ov-file#lti-11)
4. Add a new component and to set up the component, see the instruction for [Testing LTI 1.3](https://github.com/Pearson-Advance/xblock-lti-consumer/tree/pearson-release/olive.main?tab=readme-ov-file#lti-13)
5. After you publish the course, go to the LMS and see the "Staff Debug Info", look for the ``launched`` field, it should be as False
6. Make a launch and then come back to the "Staff Debug Info", to see again the ``launched`` field as True

## Jira Issue

* https://agile-jira.pearson.com/browse/PADV-2191