### PR TITLE
PAVD-2402 feat: enable enable_processor value from site configuration settings

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -679,7 +679,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Read the parameter processor functions from the settings and return their functions.
         """
-        if not self.enable_processors:
+        if not (self.enable_processors or compat.are_processors_enabled()):
             return
 
         try:

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -291,3 +291,21 @@ def nrps_pii_disallowed():
     """
     return (hasattr(settings, 'LTI_NRPS_DISALLOW_PII') and
             settings.LTI_NRPS_DISALLOW_PII is True)
+
+
+def are_processors_enabled():
+    """
+    Get 'LTI_CONSUMER_XBLOCK_ENABLE_PROCESSORS' setting from site configurations.
+    to determine if LTI Consumer XBlock processors should be enabled site-wide.
+
+    Returns:
+        True if setting is enabled.
+        False if setting is disabled.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.site_configuration import helpers
+
+    return helpers.get_current_site_configuration().get_value(
+        'LTI_CONSUMER_XBLOCK_ENABLE_PROCESSORS',
+        default=False,
+    )


### PR DESCRIPTION
## Description

This PR creates the are_processors_enabled function to enable the Send extra parameters. This way we can use the custom parameter processor site-wide, instead of enabling the feature one by one in every LTI Xblock that we need to use.

The LTI_CONSUMER_XBLOCK_ENABLE_PROCESSORS key needs to be defined as true in the Site Configuration, to enable the Parameter Processor.

## How to test

1. Install the xblock-lti-consumer with PADV-2402 branch
2. Create and configure an LTI Xblock. Here are the instruction to set an LTI Xblock with the [1.1 version](https://github.com/Pearson-Advance/xblock-lti-consumer?tab=readme-ov-file#lti-11) and with the [1.3 version](https://github.com/Pearson-Advance/xblock-lti-consumer?tab=readme-ov-file#lti-13)
3. Configure your custom parameter processor. You can create one follow these instructions [LTI Custom Parameter Processor](https://github.com/Pearson-Advance/xblock-lti-consumer/blob/pearson-release/olive.main/docs/developing.rst#defining-an-lti-parameter-processor)
4. In a Site Configuration, add to the list the setting ``"LTI_CONSUMER_XBLOCK_ENABLE_PROCESSORS":true``
5. Go to the LMS in an LTI Xblock for your Site, and launch the XBlock. You should notice the parameter processors list is ready to use.

## Jira Issue

* https://agile-jira.pearson.com/browse/PADV-2402