### PR TITLE
PADV-2388: emit event when lti1p1 content is graded

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,3 +18,4 @@ django-filter
 jsonfield
 django-config-models         # Configuration models for Django allowing config management with auditing
 openedx-filters
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -75,6 +75,8 @@ newrelic==8.5.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/base.in
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events
+    # via -r requirements/base.in
 openedx-filters==0.8.0
     # via -r requirements/base.in
 pbr==5.11.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -264,6 +264,8 @@ newrelic==8.5.0
     #   edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/test.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events
+    # via -r requirements/test.txt
 openedx-filters==0.8.0
     # via -r requirements/test.txt
 packaging==23.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,4 @@
 
 # Use edx-platform pearson-release/olive.main version
 edx-ccx-keys==1.2.1
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -106,6 +106,8 @@ newrelic==8.5.0
     #   edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/base.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events
+    # via -r requirements/base.txt
 openedx-filters==0.8.0
     # via -r requirements/base.txt
 path==16.6.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -169,6 +169,8 @@ newrelic==8.5.0
     #   edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/base.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events
+    # via -r requirements/base.txt
 openedx-filters==0.8.0
     # via -r requirements/base.txt
 pbr==5.11.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -204,6 +204,8 @@ newrelic==8.5.0
     #   edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/base.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0.post2#egg=openedx-events
+    # via -r requirements/base.txt
 openedx-filters==0.8.0
     # via -r requirements/base.txt
 pbr==5.11.1


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2388

## Description

This PR emit an event when the Outcome service request is catch and content is being graded by the LTI Tool Provider. 

## Changes Made

- [x] Adds method that emit the XBLOCK_LTI1P1_GRADED event then the LTI TP grades the content

## How to test:

1. Launch a valid LTI 1.1 content
2. Ensure the process is completed and the content is graded by the LTI TP
3. Place a debugger inside the lti_consumer/outcomes.py line #107 and ensure the event is called.

## CI falling

Currently, the CI workflows relating to testing are failing due to the changes made in the PR #16 nonetheless, here's the output of `make quality` and `make test` by commenting the changes made there. 

![image](https://github.com/user-attachments/assets/d91fb182-a1c4-4c70-b739-9b4ee305b2ba)

![image](https://github.com/user-attachments/assets/c7badd13-f909-4d48-91bb-76a0a37d9e63)

Failed action: 

https://github.com/Pearson-Advance/xblock-lti-consumer/actions/runs/16221880206/job/45804178577?pr=17

<img width="1179" height="280" alt="image" src="https://github.com/user-attachments/assets/55bff5d8-4036-4982-a288-9b48404fd383" />