### PR TITLE
PADV-2710 feat: Enable external configuration for all courses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,3 @@ jobs:
       env:
         TOXENV: ${{ matrix.toxenv }}
       run: tox
-
-    - name: Run Coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
-      uses: codecov/codecov-action@v5
-      with:
-        flags: unittests
-        fail_ci_if_error: true
-

--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -319,6 +319,15 @@ class LtiConsumer1p1:
             'Content-Type': 'application/x-www-form-urlencoded',
         }
 
+        # This block removes any leading or trailing spaces in lti parameters.
+        # We are currently experiencing a launch issue with the Measure UP LTI integration (MUP)
+        # due to some courses having leading or trailing spaces in their names.
+        # We decided to handle this from our side to avoid launch request issues
+        # and due to lack of coordination and communication with the MUP team to fix this from their side.
+        for lti_parameter, lti_parameter_value in lti_parameters.items():
+            if isinstance(lti_parameter_value, str):
+                lti_parameters[lti_parameter] = lti_parameter_value.strip()
+
         oauth_signature = get_oauth_request_signature(
             self.oauth_key,
             self.oauth_secret,

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -82,7 +82,6 @@ from .track import track_event
 from .utils import (
     _,
     resolve_custom_parameter_template,
-    external_config_filter_enabled,
     external_user_id_1p1_launches_enabled,
     database_config_enabled,
     EXTERNAL_ID_REGEX,
@@ -144,14 +143,12 @@ def valid_config_type_values(block):
     valid value options, depending on the state of the appropriate toggle.
     """
     values = [
-        {"display_name": _("Configuration on block"), "value": "new"}
+        {"display_name": _("Configuration on block"), "value": "new"},
+        {"display_name": _("Reusable Configuration"), "value": "external"},
     ]
 
     if database_config_enabled(block.scope_ids.usage_id.context_key):
         values.append({"display_name": _("Database Configuration"), "value": "database"})
-
-    if external_config_filter_enabled(block.scope_ids.usage_id.context_key):
-        values.append({"display_name": _("Reusable Configuration"), "value": "external"})
 
     return values
 
@@ -769,30 +766,16 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         currently selected for these fields. Because editable_fields defines a list of fields when that's used rendering
         the Studio edit view, it cannot support the dynamic experience we want the user to have when editing the XBlock.
         This property should return the set of all properties the user should be able to modify based on the current
-        environment. For example, if the external_config_filter_enabled flag is not enabled, the external_config field
-        should not be a part of editable_fields, because no user can edit this field in this case. On the other hand, if
-        the currently selected config_type is 'database', the fields that are otherwise stored in the database should
-        still be a part of editable_fields, because a user may select a different config_type from the menu, and we want
-        those fields to become editable at that time. The Javascript will determine when to show or to hide a given
-        field.
+        environment. For example, if the currently selected config_type is 'database', the fields that are otherwise
+        stored in the database should still be a part of editable_fields, because a user may select a different
+        config_type from the menu, and we want those fields to become editable at that time. The Javascript will
+        determine when to show or to hide a given field.
 
         Fields that are potentially filtered out include "config_type", "external_config", "ask_to_send_username",
         "ask_to_send_full_name", and "ask_to_send_email".
         """
         editable_fields = self.editable_field_names
         noneditable_fields = []
-
-        is_database_config_enabled = database_config_enabled(self.scope_ids.usage_id.context_key)
-        is_external_config_filter_enabled = external_config_filter_enabled(self.scope_ids.usage_id.context_key)
-
-        # If neither additional config_types are enabled, do not display the "config_type" field to users, as "new" is
-        # the only option and does not make sense without other options.
-        if not is_database_config_enabled and not is_external_config_filter_enabled:
-            noneditable_fields.append('config_type')
-
-        # If the enable_external_config_filter is not enabled, do not display the "external_config" field to users.
-        if not is_external_config_filter_enabled:
-            noneditable_fields.append('external_config')
 
         # update the editable fields if this XBlock is configured to not to allow the
         # editing of 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email'.

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -721,7 +721,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Read the parameter processor functions from the settings and return their functions.
         """
-        if not self.enable_processors:
+        if not (self.enable_processors or compat.are_processors_enabled()):
             return
 
         try:

--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -14,6 +14,8 @@ try:
     from xblock.utils.resources import ResourceLoader
 except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.
     from xblockutils.resources import ResourceLoader
+from openedx_events.content_authoring.data import Lti1p1ContentGraded
+from openedx_events.content_authoring.signals import XBLOCK_LTI1P1_GRADED
 
 from .exceptions import LtiError
 from .lti_1p1.oauth import verify_oauth_body_signature
@@ -94,6 +96,24 @@ class OutcomeService:
 
     def __init__(self, xblock):
         self.xblock = xblock
+
+    def emit_graded_event(self, event_data):
+        """
+        Method to emit the XBLOCK_LTI1P1_GRADED.
+
+        Args:
+            event_data (dict): Dictionary containg the input data of the event to be emitted.
+        """
+
+        # .. event_implemented_name: XBLOCK_LTI1P1_GRADED
+        # .. event_type: org.openedx.content_authoring.xblock.lti1p1.content.graded.v1
+        XBLOCK_LTI1P1_GRADED.send_event(
+            graded_content=Lti1p1ContentGraded(
+                user_id=event_data['user_id'],
+                xblock_id=event_data['xblock_id'],
+                anonymous_user_id=event_data['anonymous_user_id'],
+            )
+        )
 
     def handle_request(self, request):
         """
@@ -197,6 +217,12 @@ class OutcomeService:
         if action == 'replaceResultRequest':
             self.xblock.set_user_module_score(real_user, score, self.xblock.max_score())
 
+            event_data = {
+                'user_id': real_user.id,
+                'xblock_id': str(self.xblock.scope_ids.usage_id),
+                'anonymous_user_id': user_id
+            }
+
             values = {
                 'imsx_codeMajor': 'success',
                 'imsx_description': f'Score for {sourced_id} is now {score}',
@@ -204,6 +230,7 @@ class OutcomeService:
                 'response': '<replaceResultResponse/>'
             }
             log.debug("[LTI]: Grade is saved.")
+            self.emit_graded_event(event_data)
             return response_xml_template.format(**values)
 
         unsupported_values['imsx_messageIdentifier'] = escape(imsx_message_identifier)

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -20,18 +20,6 @@ log = logging.getLogger(__name__)
 # Namespace
 WAFFLE_NAMESPACE = 'lti_consumer'
 
-# Course Waffle Flags
-# .. toggle_name: lti_consumer.enable_external_config_filter
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enables fetching of LTI configurations from external
-#    sources like plugins using openedx-filters mechanism.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2022-03-31
-# .. toggle_tickets: https://github.com/openedx/xblock-lti-consumer/pull/239
-# .. toggle_warning: None.
-ENABLE_EXTERNAL_CONFIG_FILTER = 'enable_external_config_filter'
-
 # .. toggle_name: lti_consumer.enable_external_user_id_1p1_launches
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -65,15 +53,6 @@ ENABLE_DATABASE_CONFIG = 'enable_database_config'
 # .. toggle_tickets: None
 # .. toggle_warning: None.
 ENABLE_EXTERNAL_MULTIPLE_LAUNCH_URLS = 'enable_external_multiple_launch_urls'
-
-
-def get_external_config_waffle_flag():
-    """
-    Import and return Waffle flag for enabling external LTI configuration.
-    """
-    # pylint: disable=import-error,import-outside-toplevel
-    from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
-    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_CONFIG_FILTER}', __name__)
 
 
 def get_external_user_id_1p1_launches_waffle_flag():

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -314,3 +314,21 @@ def nrps_pii_disallowed():
     """
     return (hasattr(settings, 'LTI_NRPS_DISALLOW_PII') and
             settings.LTI_NRPS_DISALLOW_PII is True)
+
+
+def are_processors_enabled():
+    """
+    Get 'LTI_CONSUMER_XBLOCK_ENABLE_PROCESSORS' setting from site configurations.
+    to determine if LTI Consumer XBlock processors should be enabled site-wide.
+
+    Returns:
+        True if setting is enabled.
+        False if setting is disabled.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.site_configuration import helpers
+
+    return helpers.get_current_site_configuration().get_value(
+        'LTI_CONSUMER_XBLOCK_ENABLE_PROCESSORS',
+        default=False,
+    )

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -615,13 +615,10 @@ class TestEditableFields(TestLtiConsumerXBlock):
 
     def setUp(self):
         super().setUp()
-        self.mock_filter_enabled_patcher = patch("lti_consumer.lti_xblock.external_config_filter_enabled")
         self.mock_database_config_enabled_patcher = patch("lti_consumer.lti_xblock.database_config_enabled")
-        self.mock_filter_enabled = self.mock_filter_enabled_patcher.start()
         self.mock_database_config_enabled = self.mock_database_config_enabled_patcher.start()
 
     def tearDown(self):
-        self.mock_filter_enabled_patcher.stop()
         self.mock_database_config_enabled_patcher.stop()
         super().tearDown()
 
@@ -689,50 +686,18 @@ class TestEditableFields(TestLtiConsumerXBlock):
             )
         )
 
-    def test_external_config_fields_are_editable_only_when_waffle_flag_is_set(self):
-        """
-        Test that the external configuration fields are editable only when the waffle flag is set.
-        """
-        self.mock_filter_enabled.return_value = True
-        self.assertTrue(self.are_fields_editable(fields=['config_type', 'external_config']))
-
-        self.mock_filter_enabled.return_value = False
-        self.assertFalse(self.are_fields_editable(fields=['config_type', 'external_config']))
-
-    @ddt.idata(product([True, False], [True, False]))
-    @ddt.unpack
-    def test_database_config_fields_are_editable_only_when_waffle_flag_is_set(self, filter_enabled, db_enabled):
-        """
-        Test that the database configuration fields are editable only when the waffle flag is set.
-        """
-        self.mock_filter_enabled.return_value = filter_enabled
-
-        assert_fn = None
-        # If either flag is enabled, 'config_type' should be editable.
-        if db_enabled or filter_enabled:
-            assert_fn = self.assertTrue
-        else:
-            assert_fn = self.assertFalse
-
-        self.mock_database_config_enabled.return_value = db_enabled
-
-        assert_fn(self.are_fields_editable(fields=['config_type']))
-
-    @ddt.idata(product([True, False], [True, False]))
-    @ddt.unpack
-    def test_config_type_values(self, filter_enabled, db_enabled):
+    @ddt.data(True, False)
+    def test_config_type_values(self, db_enabled):
         """
         Test that only the appropriate values for config_type are available as options, depending on the state of the
         appropriate waffle flags.
         """
-        self.mock_filter_enabled.return_value = filter_enabled
         self.mock_database_config_enabled.return_value = db_enabled
 
         values = valid_config_type_values(self.xblock)
 
-        expected_values = ["new"]
-        if self.mock_filter_enabled:
-            expected_values.append('external')
+        expected_values = ["new", "external"]
+
         if self.mock_database_config_enabled:
             expected_values.append('database')
 
@@ -1781,15 +1746,12 @@ class TestLtiConsumer1p3XBlock(TestCase):
         }
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
 
-        self.mock_filter_enabled_patcher = patch("lti_consumer.lti_xblock.external_config_filter_enabled")
         self.mock_database_config_enabled_patcher = patch("lti_consumer.lti_xblock.database_config_enabled")
         self.mock_external_multiple_launch_urls_enabled = patch(
             "lti_consumer.lti_xblock.external_multiple_launch_urls_enabled"
         )
-        self.mock_filter_enabled = self.mock_filter_enabled_patcher.start()
         self.mock_database_config_enabled = self.mock_database_config_enabled_patcher.start()
         self.mock_external_multiple_launch_urls_enabled.start()
-        self.addCleanup(self.mock_filter_enabled_patcher.stop)
         self.addCleanup(self.mock_database_config_enabled_patcher.stop)
         self.addCleanup(self.mock_external_multiple_launch_urls_enabled.stop)
 

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from edx_django_utils.cache import get_cache_key, TieredCache
 
 from lti_consumer.plugin.compat import (
-    get_external_config_waffle_flag,
     get_external_user_id_1p1_launches_waffle_flag,
     get_database_config_waffle_flag,
     get_external_multiple_launch_urls_waffle_flag,
@@ -200,16 +199,6 @@ def resolve_custom_parameter_template(xblock, template):
         return template
 
     return template_value
-
-
-def external_config_filter_enabled(course_key):
-    """
-    Returns True if external config filter is enabled for the course via Waffle Flag.
-
-    Arguments:
-        course_key (opaque_keys.edx.locator.CourseLocator): Course Key
-    """
-    return get_external_config_waffle_flag().is_enabled(course_key)
 
 
 def external_user_id_1p1_launches_enabled(course_key):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,3 +18,4 @@ jsonfield
 django-config-models         # Configuration models for Django allowing config management with auditing
 openedx-filters
 django-statici18n
+openedx-events

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,9 @@ appdirs==1.4.4
 asgiref==3.11.0
     # via django
 attrs==25.4.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   openedx-events
 bleach==6.3.0
     # via -r requirements/base.in
 cffi==2.0.0
@@ -29,6 +31,7 @@ django==5.2.10
     #   djangorestframework
     #   edx-django-utils
     #   jsonfield
+    #   openedx-events
     #   openedx-filters
 django-appconf==1.2.0
     # via django-statici18n
@@ -47,14 +50,21 @@ djangorestframework==3.16.1
 dnspython==2.8.0
     # via pymongo
 edx-ccx-keys==2.0.2
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   openedx-events
 edx-django-utils==8.0.1
-    # via django-config-models
+    # via
+    #   django-config-models
+    #   openedx-events
 edx-opaque-keys[django]==3.0.0
     # via
     #   -r requirements/base.in
     #   edx-ccx-keys
+    #   openedx-events
     #   openedx-filters
+fastavro==1.12.1
+    # via openedx-events
 fs==2.4.16
     # via xblock
 jsonfield==3.2.0
@@ -75,8 +85,14 @@ markupsafe==3.0.3
     #   xblock
 oauthlib==3.3.1
     # via -r requirements/base.in
-openedx-filters==2.1.0
-    # via -r requirements/base.in
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+openedx-filters @ git+https://github.com/Pearson-Advance/openedx-filters.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 psutil==7.2.1
     # via edx-django-utils
 pycparser==3.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,9 @@ astroid==4.0.3
     #   pylint
     #   pylint-celery
 attrs==25.4.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 backports-tarfile==1.2.0
     # via
     #   -r requirements/test.txt
@@ -96,9 +98,7 @@ coverage[toml]==7.13.2
 coveralls==4.0.2
     # via -r requirements/test.txt
 cryptography==46.0.3
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
+    # via -r requirements/test.txt
 ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.4.1
@@ -122,6 +122,7 @@ django==5.2.10
     #   djangorestframework
     #   edx-django-utils
     #   jsonfield
+    #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-appconf==1.2.0
@@ -159,18 +160,26 @@ docutils==0.22.4
     #   -r requirements/test.txt
     #   readme-renderer
 edx-ccx-keys==2.0.2
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
+    #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/test.txt
 edx-opaque-keys[django]==3.0.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
+    #   openedx-events
     #   openedx-filters
+fastavro==1.12.1
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 filelock==3.20.3
     # via
     #   -r requirements/tox.txt
@@ -213,11 +222,6 @@ jaraco-functools==4.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jeepney==0.9.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
@@ -276,8 +280,14 @@ nh3==0.3.2
     #   readme-renderer
 oauthlib==3.3.1
     # via -r requirements/test.txt
-openedx-filters==2.1.0
-    # via -r requirements/test.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+openedx-filters @ git+https://github.com/Pearson-Advance/openedx-filters.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 packaging==26.0
     # via
     #   -r requirements/test.txt

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,7 @@
 urllib3<1.27,>=1.25.4
 
 backports-zoneinfo==0.2.1 ; python_version < "3.9"
+
+# Using openedx-events/filters Pearson fork for Ulmo version
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@pearson/ulmo#egg=openedx-events
+openedx-filters @ git+https://github.com/Pearson-Advance/openedx-filters.git@pearson/ulmo#egg=openedx-filters

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,9 @@ asgiref==3.11.0
     #   -r requirements/base.txt
     #   django
 attrs==25.4.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 bleach==6.3.0
     # via -r requirements/base.txt
 cffi==2.0.0
@@ -26,6 +28,7 @@ click==8.3.1
     #   edx-django-utils
 django==5.2.10
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   django-appconf
     #   django-config-models
@@ -37,6 +40,7 @@ django==5.2.10
     #   edx-django-utils
     #   edx-i18n-tools
     #   jsonfield
+    #   openedx-events
     #   openedx-filters
 django-appconf==1.2.0
     # via
@@ -65,18 +69,26 @@ dnspython==2.8.0
     #   -r requirements/base.txt
     #   pymongo
 edx-ccx-keys==2.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
+    #   openedx-events
 edx-i18n-tools==1.9.0
     # via -r requirements/dev.in
 edx-opaque-keys[django]==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
+    #   openedx-events
     #   openedx-filters
+fastavro==1.12.1
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -104,7 +116,9 @@ markupsafe==3.0.3
     #   xblock
 oauthlib==3.3.1
     # via -r requirements/base.txt
-openedx-filters==2.1.0
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@pearson/ulmo
+    # via -r requirements/base.txt
+openedx-filters @ git+https://github.com/Pearson-Advance/openedx-filters.git@pearson/ulmo
     # via -r requirements/base.txt
 path==16.16.0
     # via edx-i18n-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,7 +19,9 @@ astroid==4.0.3
     #   pylint
     #   pylint-celery
 attrs==25.4.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 binaryornot==0.4.4
     # via cookiecutter
 bleach==6.3.0
@@ -74,6 +76,7 @@ django==5.2.10
     #   djangorestframework
     #   edx-django-utils
     #   jsonfield
+    #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-appconf==1.2.0
@@ -103,18 +106,26 @@ dnspython==2.8.0
     #   -r requirements/base.txt
     #   pymongo
 edx-ccx-keys==2.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
+    #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/quality.in
 edx-opaque-keys[django]==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
+    #   openedx-events
     #   openedx-filters
+fastavro==1.12.1
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -161,8 +172,14 @@ mdurl==0.1.2
     # via markdown-it-py
 oauthlib==3.3.1
     # via -r requirements/base.txt
-openedx-filters==2.1.0
-    # via -r requirements/base.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+openedx-filters @ git+https://github.com/Pearson-Advance/openedx-filters.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 platformdirs==4.5.1
     # via pylint
 psutil==7.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,9 @@ astroid==4.0.3
     #   pylint
     #   pylint-celery
 attrs==25.4.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 backports-tarfile==1.2.0
     # via jaraco-context
 binaryornot==0.4.4
@@ -62,9 +64,7 @@ coverage[toml]==7.13.2
 coveralls==4.0.2
     # via -r requirements/test.in
 cryptography==46.0.3
-    # via
-    #   -r requirements/test.in
-    #   secretstorage
+    # via -r requirements/test.in
 ddt==1.7.2
     # via -r requirements/test.in
 dill==0.4.1
@@ -81,6 +81,7 @@ dill==0.4.1
     #   djangorestframework
     #   edx-django-utils
     #   jsonfield
+    #   openedx-events
     #   openedx-filters
     #   xblock-sdk
 django-appconf==1.2.0
@@ -115,18 +116,26 @@ docopt==0.6.2
 docutils==0.22.4
     # via readme-renderer
 edx-ccx-keys==2.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
+    #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/test.in
 edx-opaque-keys[django]==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
+    #   openedx-events
     #   openedx-filters
+fastavro==1.12.1
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -148,10 +157,6 @@ jaraco-context==6.1.0
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   code-annotations
@@ -197,8 +202,14 @@ nh3==0.3.2
     # via readme-renderer
 oauthlib==3.3.1
     # via -r requirements/base.txt
-openedx-filters==2.1.0
-    # via -r requirements/base.txt
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+openedx-filters @ git+https://github.com/Pearson-Advance/openedx-filters.git@pearson/ulmo
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 packaging==26.0
     # via twine
 platformdirs==4.5.1


### PR DESCRIPTION
## Description

This PR support the Open Edx Ulmo version, including some custom changes that we are using in Olive version, and they are necessary to complete the functionality in the new version.

## Related PRs

* https://github.com/Pearson-Advance/xblock-lti-consumer/pull/11
* https://github.com/Pearson-Advance/xblock-lti-consumer/pull/13
* https://github.com/Pearson-Advance/xblock-lti-consumer/pull/16
* https://github.com/Pearson-Advance/xblock-lti-consumer/pull/17

## How to test

1. Create an ulmo tutor environment, using the vue/PADV-2710 branch
2. From Studio, add and LTI xblock. Use the steps to configure the xblock defined here: https://github.com/Pearson-Advance/xblock-lti-consumer/tree/pearson/ulmo?tab=readme-ov-file#testing-against-an-lti-provider

**Note:** For more information or better testing, see the description in the PRs #11, #16 and #17

## Issue

- https://pearson.atlassian.net/browse/PADV-2710

## Changes that no longer need to be supported in our branches

- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/2 -> https://github.com/openedx/xblock-lti-consumer/pull/392
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/3 Removed in https://github.com/Pearson-Advance/xblock-lti-consumer/commit/28e1e69f98020a4f0fde63c8368360e208d5e9d9#diff-6e408862179502a0ac809fab914e028b18311a17a3b0874469bd6416bc4a449fL10
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/4 Implemented here https://github.com/openedx/xblock-lti-consumer/commit/d3686bf14ca666985750dae1205536a6d31b1cb8#diff-cc618c2e63b8c2d293d245f9799381d9321e40fe2d05e9a4b2f80bb91995157dR100-R103
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/6 Removed here https://github.com/Pearson-Advance/xblock-lti-consumer/commit/51c93804c002f50fcdfca3e0a19d8deb6b86d506#diff-bf080bd24f489dfd5347d39794d91e95f5a58f7863ed622a447bb1253e1107ceL10-L237
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/7 Implemented here https://github.com/openedx/xblock-lti-consumer/commit/d3686bf14ca666985750dae1205536a6d31b1cb8#diff-cc618c2e63b8c2d293d245f9799381d9321e40fe2d05e9a4b2f80bb91995157dR1579-R1587
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/8 I was unable to replicate the bug described in the PR in the Ulmo version, so this change is not necessary.
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/9 was cover by https://github.com/openedx/xblock-lti-consumer/pull/390 and https://github.com/openedx/xblock-lti-consumer/pull/557
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/10 -> https://github.com/openedx/xblock-lti-consumer/pull/391
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/12 The lines changes was removed in this PR https://github.com/openedx/xblock-lti-consumer/pull/575
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/15 The line was modified in this PR https://github.com/openedx/xblock-lti-consumer/pull/523
- https://github.com/Pearson-Advance/xblock-lti-consumer/pull/18 Solved in this PR https://github.com/openedx/xblock-lti-consumer/pull/500