### PR TITLE
PADV-3234: OutcomeService source secret from self.xblock._get_lti_consumer

### DIFF
--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -196,9 +196,9 @@ class OutcomeService:
             return response_xml_template.format(**failure_values)
 
         # Verify OAuth signing.
-        __, secret = self.xblock.lti_provider_key_secret
+        lti_consumer = self.xblock._get_lti_consumer()  # pylint: disable=protected-access
         try:
-            verify_oauth_body_signature(request, secret, self.xblock.outcome_service_url)
+            verify_oauth_body_signature(request, lti_consumer.oauth_secret, self.xblock.outcome_service_url)
         except (ValueError, LtiError) as ex:
             failure_values['imsx_messageIdentifier'] = escape(imsx_message_identifier)
             error_message = "OAuth verification error: " + escape(str(ex))

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -348,7 +348,10 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.mock_get_user_id_patcher_enabled.return_value = mock_user
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch(
+        'lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer',
+        PropertyMock(oauth_secret='s'),
+    )
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_handle_replace_result_success(self):
         """
@@ -407,7 +410,10 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('Request body XML parsing error', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch(
+        'lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer',
+        PropertyMock(oauth_secret='s'),
+    )
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_invalid_signature(self, mock_verify):
         """
@@ -422,7 +428,10 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('failure', self.outcome_service.handle_request(request))
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch(
+        'lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer',
+        PropertyMock(oauth_secret='s'),
+    )
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_user_not_found(self):
         """
@@ -437,7 +446,10 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('User not found', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch(
+        'lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer',
+        PropertyMock(oauth_secret='s'),
+    )
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'unsupportedRequest')))
     def test_unsupported_action(self):
         """


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-3234

### Description

This PR fixes the LTI 1.1 `OutcomeService` mechanism to obtain the LTI 1.1 OAuth secret. This `OutcomeService.handle_request` method was sourcing the LTI 1.1 OAuth secret from the `LtiConsumerXBlock.lti_provider_key_secret` property, this was generating issues when the XBlock was configured to use an external LTI configuration since the `lti_provider_key_secret` property only sources the OAuth secret from the XBlock itself and not the external configuration model. In order to fix this the OAuth secret is instead obtained from the class returned by `LtiConsumerXBlock._get_lti_consumer` method, this class contains a `oauth_secret` property which will return the OAuth secret from the configured storing mechanism of the LTI XBlock.

### Testing

1. Create an external LTI configuration for saLTIre.
1. Configure an LTI 1.1 XBlock using the created external LTI configuration.
2. Configure the LTI 1.1 XBlock has scored.
3. Execute the LTI 1.1 launch.
4. Go to the "Services Available" tab.
5. Click on "Basic Outcomes" link.
6. Set an "Outcome value" to any digit value.
7. Click on the "Update" button.
8. The request should be successful.