### PR TITLE
PADV-3245: Enable PII sharing on all courses

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -739,22 +739,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         fields ask_to_send_username, ask_to_send_full_name, and ask_to_send_email are displayed in Studio and whether
         these data are shared in LTI launches, regardless of the values of the settings on the XBlock.
         """
-        config_service = self.runtime.service(self, 'lti-configuration')
-        if config_service:
-            is_already_sharing_learner_info = (
-                self.ask_to_send_username or
-                self.ask_to_send_full_name or
-                self.ask_to_send_email
-            )
-            return config_service.configuration.lti_access_to_learners_editable(
-                self.scope_ids.usage_id.context_key,
-                is_already_sharing_learner_info,
-            )
-
-        # TODO: The LTI configuration service is currently only available from the studio_view. This means that
-        #       the CourseAllowPIISharingInLTIFlag does not control PII sharing in the author_view or student_view,
-        #       because the service is not defined in those contexts.
-        return True
+        return compat.get_pii_sharing_waffle_flag().is_enabled()
 
     @property
     def editable_fields(self):

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -54,6 +54,16 @@ ENABLE_DATABASE_CONFIG = 'enable_database_config'
 # .. toggle_warning: None.
 ENABLE_EXTERNAL_MULTIPLE_LAUNCH_URLS = 'enable_external_multiple_launch_urls'
 
+# .. toggle_name: lti_consumer.allow_pii_sharing
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Allows sharing of PII data across the platform.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2026-04-15
+# .. toggle_tickets: None
+# .. toggle_warning: None.
+ALLOW_PII_SHARING = 'allow_pii_sharing'
+
 
 def get_external_user_id_1p1_launches_waffle_flag():
     """
@@ -77,6 +87,15 @@ def get_external_multiple_launch_urls_waffle_flag():  # pragma: nocover
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
     return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_MULTIPLE_LAUNCH_URLS}', __name__)
+
+
+def get_pii_sharing_waffle_flag():
+    """"
+    Import and return Waffle flag for allowing sharing of PII data across the platform.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from edx_toggles.toggles import WaffleSwitch
+    return WaffleSwitch(f'{WAFFLE_NAMESPACE}.{ALLOW_PII_SHARING}', __name__)
 
 
 def load_enough_xblock(location):  # pragma: nocover

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -25,7 +25,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
-from lti_consumer.api import get_lti_pii_sharing_state_for_course, validate_lti_1p3_launch_data
+from lti_consumer.api import validate_lti_1p3_launch_data
 from lti_consumer.exceptions import LtiError, ExternalConfigurationNotFound
 from lti_consumer.lti_1p3.consumer import LtiConsumer1p3, LtiProctoringConsumer
 from lti_consumer.lti_1p3.exceptions import (BadJwtSignature, InvalidClaimValue, Lti1p3Exception,
@@ -818,8 +818,7 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
         Overrides ModelViewSet's `get_serializer_class` method.
         Checks if PII fields can be exposed and returns appropiate serializer.
         """
-        if (not compat.nrps_pii_disallowed() and
-                get_lti_pii_sharing_state_for_course(self.request.lti_configuration.location.course_key)):
+        if (not compat.nrps_pii_disallowed() and compat.get_pii_sharing_waffle_flag().is_enabled()):
             return LtiNrpsContextMembershipPIISerializer
         else:
             return LtiNrpsContextMembershipBasicSerializer

--- a/lti_consumer/tests/test_utils.py
+++ b/lti_consumer/tests/test_utils.py
@@ -92,19 +92,3 @@ defaulting_processor.lti_xblock_default_params = {
     'custom_name': 'Lex',
     'custom_country': '',
 }
-
-
-def get_mock_lti_configuration(editable):
-    """
-    Returns a mock object of lti-configuration service
-
-    Arguments:
-        editable (bool): This indicates whether the LTI fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name',
-        and 'ask_to_send_email') are editable.
-    """
-    lti_configuration = Mock()
-    lti_configuration.configuration = Mock()
-    lti_configuration.configuration.lti_access_to_learners_editable = Mock(
-        return_value=editable
-    )
-    return lti_configuration

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -213,7 +213,10 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         response = self.client.get(self.context_membership_endpoint)
         self.assertEqual(response.status_code, 403)
 
-    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.compat.get_pii_sharing_waffle_flag',
+        Mock(is_enabled=Mock(return_value=False)),
+    )
     @patch(
         'lti_consumer.plugin.views.compat.get_course_members',
         Mock(side_effect=patch_get_memberships()),
@@ -227,24 +230,27 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['content-type'], 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json')
 
-    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', return_value=False)
+    @patch(
+        'lti_consumer.plugin.views.compat.get_pii_sharing_waffle_flag'
+    )
     @patch(
         'lti_consumer.plugin.views.compat.get_course_members',
         Mock(side_effect=patch_get_memberships({
             'student': 4
         })),
     )
-    def test_get_without_pii(self, expose_pii_fields_patcher):
+    def test_get_without_pii(self, get_pii_sharing_waffle_flag_mock):
         """
         Test context membership endpoint response structure with PII not exposed.
         """
+        get_pii_sharing_waffle_flag_mock.return_value.is_enabled.return_value = False
         self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
         response = self.client.get(self.context_membership_endpoint)
         self.assertEqual(response.data['id'], 'http://testserver{}'.format(self.context_membership_endpoint))
         self.assertEqual(len(response.data['members']), 4)
         self.assertEqual(response.has_header('Link'), False)
 
-        expose_pii_fields_patcher.assert_called()
+        get_pii_sharing_waffle_flag_mock.assert_called()
 
         # name & email should not be exposed.
         member_fields = response.data['members'][0].keys()
@@ -254,17 +260,20 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         self.assertNotIn('email', member_fields)
         self.assertNotIn('name', member_fields)
 
-    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', return_value=True)
+    @patch(
+        'lti_consumer.plugin.views.compat.get_pii_sharing_waffle_flag'
+    )
     @patch(
         'lti_consumer.plugin.views.compat.get_course_members',
         Mock(side_effect=patch_get_memberships({
             'student': 4
         })),
     )
-    def test_get_with_pii(self, expose_pii_fields_patcher):
+    def test_get_with_pii(self, get_pii_sharing_waffle_flag_mock):
         """
         Test context membership endpoint response structure with PII exposed.
         """
+        get_pii_sharing_waffle_flag_mock.return_value.is_enabled.return_value = True
         self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
         response = self.client.get(self.context_membership_endpoint)
 
@@ -272,7 +281,7 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         self.assertEqual(len(response.data['members']), 4)
         self.assertEqual(response.has_header('Link'), False)
 
-        expose_pii_fields_patcher.assert_called()
+        get_pii_sharing_waffle_flag_mock.assert_called()
 
         # name & email should be present along with user_id, roles etc.
         member_fields = response.data['members'][0].keys()
@@ -282,7 +291,10 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         self.assertIn('email', member_fields)
         self.assertIn('name', member_fields)
 
-    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_pii_sharing_waffle_flag',
+        Mock(is_enabled=Mock(return_value=False)),
+    )
     @patch(
         'lti_consumer.plugin.views.compat.get_course_members',
         Mock(side_effect=patch_get_memberships({

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -27,7 +27,6 @@ from lti_consumer.lti_1p3.tests.utils import create_jwt
 from lti_consumer.tests import test_utils
 from lti_consumer.tests.test_utils import (
     FAKE_USER_ID,
-    get_mock_lti_configuration,
     make_jwt_request,
     make_request,
     make_xblock,
@@ -631,36 +630,25 @@ class TestEditableFields(TestLtiConsumerXBlock):
         """
         return all(field in self.xblock.editable_fields for field in fields)
 
-    def test_editable_fields_with_no_config(self):
-        """
-        Test that LTI XBlock's fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email')
-        are editable when lti-configuration service is not provided.
-        """
-        self.xblock.runtime.service.return_value = None
-        # Assert that 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email' are editable.
-        self.assertTrue(
-            self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
-        )
-
-    def test_editable_fields_when_editing_allowed(self):
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
+    def test_editable_fields_when_editing_allowed(self, get_pii_sharing_waffle_flag_mock):
         """
         Test that LTI XBlock's fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email')
         are editable when this XBlock is configured to allow it.
         """
-        # this XBlock is configured to allow editing of LTI fields
-        self.xblock.runtime.service.return_value = get_mock_lti_configuration(editable=True)
+        get_pii_sharing_waffle_flag_mock.return_value.is_enabled.return_value = True
         # Assert that 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email' are editable.
         self.assertTrue(
             self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
         )
 
-    def test_editable_fields_when_editing_not_allowed(self):
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
+    def test_editable_fields_when_editing_not_allowed(self, get_pii_sharing_waffle_flag_mock):
         """
         Test that LTI XBlock's fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email')
         are not editable when this XBlock is configured to not to allow it.
         """
-        # this XBlock is configured to not to allow editing of LTI fields
-        self.xblock.runtime.service.return_value = get_mock_lti_configuration(editable=False)
+        get_pii_sharing_waffle_flag_mock.return_value.is_enabled.return_value = False
         # Assert that 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email' are not editable.
         self.assertFalse(
             self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
@@ -1926,7 +1914,8 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         self.assertEqual(self.xblock.get_context_title(), "DemoX - edX")
 
-    def test_studio_view(self):
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
+    def test_studio_view(self, mock_get_pii_sharing_waffle_flag):  # pylint: disable=unused-argument
         """
         Test that the studio settings view load the custom js.
         """
@@ -1955,9 +1944,15 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.assertIn("mock-keyset_url", response.content)
         self.assertIn("mock-token_url", response.content)
 
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
     @patch('lti_consumer.api.get_lti_1p3_content_url')
-    def test_student_view(self, mock_get_lti_1p3_content_url, mock_get_lti_1p3_launch_data):
+    def test_student_view(
+        self,
+        mock_get_lti_1p3_content_url,
+        mock_get_lti_1p3_launch_data,
+        mock_get_pii_sharing_waffle_flag,  # pylint: disable=unused-argument
+    ):
         """
         Test that the student view is displayed as expected
         """
@@ -1986,6 +1981,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.assertEqual(response.js_init_fn, 'LtiConsumerXBlock')
         self.assertNotIn("LTI 1.3 Launches can only be performed from the LMS", response.content)
 
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
     @patch('lti_consumer.api.get_lti_1p3_launch_info')
     @patch('lti_consumer.api.get_lti_1p3_content_url')
@@ -1994,6 +1990,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
         mock_get_lti_1p3_content_url,
         mock_get_launch_info,
         mock_get_lti_1p3_launch_data,
+        mock_get_pii_sharing_waffle_flag,  # pylint: disable=unused-argument
     ):
         """
         Test that the author view content is displayed with the student view when viewed by a staff user.
@@ -2344,45 +2341,25 @@ class TestSubmitStudioEditsHandler(TestLtiConsumerXBlock):
         self.addCleanup(external_config_flag_patcher.stop)
 
 
-@ddt.ddt
 class TestGetPiiSharingEnabled(TestLtiConsumerXBlock):
     """
     Unit tests for LtiConsumerXBlock.get_pii_sharing_enabled.
     """
-    def test_no_service(self):
+
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
+    def test_with_flag_disabled(self, mock_get_pii_sharing_waffle_flag):
+        """
+        Test with disabled flag.
+        """
+        mock_get_pii_sharing_waffle_flag.return_value.is_enabled.return_value = False
+
+        self.assertFalse(self.xblock.get_pii_sharing_enabled())
+
+    @patch('lti_consumer.lti_xblock.compat.get_pii_sharing_waffle_flag')
+    def test_with_flag_enabled(self, mock_get_pii_sharing_waffle_flag):
+        """
+        Test with enabled flag.
+        """
+        mock_get_pii_sharing_waffle_flag.return_value.is_enabled.return_value = True
+
         self.assertTrue(self.xblock.get_pii_sharing_enabled())
-
-    @ddt.data(True, False)
-    def test_lti_access_to_learners_editable(self, lti_access_to_learners_editable):
-        """
-        Test that the get_pii_sharing_enabled method returns the value of calling the lti_access_to_learners_editable
-        method of the LTI configuration service, so long as as the configuration service is available and defined.
-        """
-        self.xblock.runtime.service.return_value = get_mock_lti_configuration(
-            editable=lti_access_to_learners_editable
-        )
-        self.assertEqual(self.xblock.get_pii_sharing_enabled(), lti_access_to_learners_editable)
-
-    @ddt.idata(product([True, False], [True, False], [True, False]))
-    @ddt.unpack
-    def test_lti_access_to_learners_editable_args(self, ask_to_send_username, ask_to_send_full_name, ask_to_send_email):
-        """
-        Test that the lti_access_to_learners_editable_mock method of the LTI configuration service is called with the
-        the correct arguments.
-        """
-        lti_configuration = Mock()
-        lti_configuration.configuration = Mock()
-        lti_access_to_learners_editable_mock = Mock()
-        lti_configuration.configuration.lti_access_to_learners_editable = lti_access_to_learners_editable_mock
-        self.xblock.runtime.service.return_value = lti_configuration
-
-        self.xblock.ask_to_send_username = ask_to_send_username
-        self.xblock.ask_to_send_full_name = ask_to_send_full_name
-        self.xblock.ask_to_send_email = ask_to_send_email
-
-        self.xblock.get_pii_sharing_enabled()
-
-        lti_access_to_learners_editable_mock.assert_called_once_with(
-            self.xblock.scope_ids.usage_id.context_key,
-            ask_to_send_username or ask_to_send_full_name or ask_to_send_email,
-        )


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-3245

### Description

This PR adds modifies the LTI Consumer XBlock to allow sharing PII data on all courses, this was done by adding a new `lti_consumer.allow_pii_sharing` waffle switch, the fields `ask_to_send_username`, `ask_to_send_full_name` and `ask_to_send_email` still control whether the LTI launch will share the username or email but now the controls are editable on all LTI Consumer XBlocks across all courses.

### Testing 

1. Add a new waffle switch: http://localhost:18010/admin/waffle/switch/
2. Set the switch name `lti_consumer.allow_pii_sharing` and enable the switch.
3. Create an LTI Consumer XBlock on a course.
4. The "Request user's email", "Request user's username" and "Request user's full name" fields should be editable.
5. Set all the PII fields to True.
6. Execute an LTI launch to IMS RI or saLTIre.
7. The PII data should be present on the launch data.
8. Disable the waffle switch.
9. Go to edit the previously created LTI Consumer XBlock.
10. The PII fields should not be present.
11. Execute an LTI launch to IMS RI or saLTIre.
12. The PII data shouldn't be present on the launch data.