### PR TITLE
PADV-3611: Add missing data to event tracking

### DIFF
--- a/lti_consumer/lti_1p1/contrib/django.py
+++ b/lti_consumer/lti_1p1/contrib/django.py
@@ -133,6 +133,7 @@ def lti_embed(
         'lti_version': lti_parameters.get('lti_version'),
         'user_roles': lti_parameters.get('roles'),
         'launch_url': lti_consumer.lti_launch_url,
+        'custom_parameters': custom_parameters,
     }
     track_event('embed.launch_request', event)
 

--- a/lti_consumer/lti_1p1/contrib/tests/test_django.py
+++ b/lti_consumer/lti_1p1/contrib/tests/test_django.py
@@ -171,5 +171,6 @@ class TestLtiEmbed(TestCase):
                 'lti_version': 'LTI_1p1',
                 'user_roles': self.roles,
                 'launch_url': self.lti_launch_url,
+                'custom_parameters': {},
             }
         )

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1295,12 +1295,15 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             lti_consumer.set_launch_presentation_locale(real_user_data['user_language'])
 
         lti_consumer.set_custom_parameters(self.prefixed_custom_parameters)
+        extra_claims = {}
 
         for processor in self.get_parameter_processors():
             try:
                 default_params = getattr(processor, 'lti_xblock_default_params', {})
+                extra_claims = processor(self) or {}
                 lti_consumer.set_extra_claims(default_params)
-                lti_consumer.set_extra_claims(processor(self) or {})
+                lti_consumer.set_extra_claims(extra_claims)
+                extra_claims.update(dict(default_params, **extra_claims))
             except Exception:  # pylint: disable=broad-except
                 # Log the error without causing a 500-error.
                 # Useful for catching casual runtime errors in the processors.
@@ -1313,6 +1316,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'lti_version': lti_parameters.get('lti_version'),
             'user_roles': lti_parameters.get('roles'),
             'launch_url': lti_consumer.lti_launch_url,
+            'custom_parameters': {**self.prefixed_custom_parameters, **extra_claims},
         }
         track_event('xblock.launch_request', event)
 

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -363,7 +363,10 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         event = {
             'lti_version': lti_config.version,
             'user_roles': user_role,
-            'launch_url': context['launch_url']
+            'launch_url': context['launch_url'],
+            'context_id': launch_data.context_id,
+            'resource_link_id': launch_data.resource_link_id,
+            'custom_parameters': launch_data.custom_parameters,
         }
         track_event('xblock.launch_request', event)
 

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -350,6 +350,39 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         self.assertIn("state", content)
         self.assertIn("hello-world", content)
 
+    @patch('lti_consumer.plugin.views.track_event')
+    def test_lti_launch_response_tracks_all_event_data(self, mock_track_event):
+        """
+        Check that launch tracking events include all expected launch metadata.
+        """
+        self.launch_data.context_id = 'course-v1:testX+TST101+2026_T2'
+        self.launch_data.resource_link_id = 'resource_link_id'
+        self.launch_data.custom_parameters = {'test': 'value'}
+        launch_data_key = cache_lti_1p3_launch_data(self.launch_data)
+
+        params = {
+            "nonce": "nonce-value",
+            "state": "hello-world",
+            "redirect_uri": "https://tool.example",
+            "client_id": self.config.lti_1p3_client_id,
+            "login_hint": self.launch_data.user_id,
+            "lti_message_hint": launch_data_key,
+        }
+        response = self.client.get(self.url, params)
+
+        self.assertEqual(response.status_code, 200)
+        mock_track_event.assert_called_once_with(
+            'xblock.launch_request',
+            {
+                'lti_version': 'lti_1p3',
+                'user_roles': 'student',
+                'launch_url': 'https://tool.example',
+                'context_id': 'course-v1:testX+TST101+2026_T2',
+                'resource_link_id': 'resource_link_id',
+                'custom_parameters': {'test': 'value'},
+            }
+        )
+
     def test_launch_callback_endpoint_fails(self):
         """
         Test that the LTI 1.3 callback endpoint correctly display an error message.

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1044,6 +1044,11 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
                 'lti_version': 'LTI_1p3',
                 'user_roles': 'Student',
                 'launch_url': 'https://test.co',
+                'custom_parameters': {
+                    'custom_component_display_name': 'LTI Consumer',
+                    'custom_component_due_date': self.xblock.due.strftime('%Y-%m-%d %H:%M:%S'),
+                    'custom_component_graceperiod': str(self.xblock.graceperiod.total_seconds()),
+                },
             }
         )
 


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-3611

### Description

This PR modifies the [event-tracking](https://github.com/openedx/event-tracking) calls to include missing data in the LTI launch event tracking. This data will be used in the PR of PADV-3612 to replace the existing mechanism to register launch events, we needed to add this data so we could have all the required data to replace the existing mechanism with the [event-tracking](https://github.com/openedx/event-tracking) calls.